### PR TITLE
feat: raquet_merge_bands(LIST<VARCHAR>) — combine single-band raquets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 duckdb_unittest_tempdir/
 # GDAL stats sidecars written next to test rasters
 *.aux.xml
+
+# Claude Code workspace (plans, settings, worktrees)
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,11 @@ The `read_raster()` table function converts raster files to raquet format:
 1. **Bind**: Opens raster with GDAL, detects CRS/bands/resolution, calculates zoom, defines output schema
 2. **InitGlobal**: Builds native-zoom tile list and overview frame list
 3. **InitLocal**: Each thread opens its own `GDALDatasetH` handle (GDAL is not thread-safe per handle)
-4. **Execute (Phase 1)**: Native-zoom tiles processed in parallel — threads pull from mutex-protected queue
-5. **Execute (Phase 2)**: Overview tiles processed single-threaded (depend on child tiles)
-6. **Execute (Phase 3)**: Metadata row emitted last (block=0)
+4. **Execute (Phase 1)**: Native-zoom tiles processed in parallel — threads pull from mutex-protected queue, warp from source base resolution, emit rows directly to the output DataChunk.
+5. **Execute (Phase 2)**: Overview tiles processed in parallel via a work queue — one thread (the init winner) waits for Phase 1 stragglers and publishes `overview_frames`, then all workers pull from it. Uses COG fast path when source overviews exist (reads matching source overview level instead of re-warping from base). Results staged in `overview_results` so emission can span multiple Execute() calls.
+6. **Execute (Phase 3)**: Drain staged overview rows into output DataChunks; finally emit the metadata row at `block=0` (exactly once, via CAS on `metadata_emitted`).
+
+Set `RAQUET_DEBUG_TIMING=1` to emit per-phase wall-time markers to stderr (`[raquet-phase] ...`). See `src/raster/read_raster.cpp` near `ReadRasterGlobalState` for the detailed state-machine doc.
 
 Pipeline per tile: `CreateTileDataset → WarpIntoTile → IsTileEmpty → ReadAndCompressBands → EmitTileRow`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(GDAL_FOUND)
     message(STATUS "GDAL support enabled (read_raster available)")
     list(APPEND EXTENSION_SOURCES
         src/raster/read_raster.cpp
-        src/raster/band_stats_v01.cpp)
+        src/raster/band_stats.cpp)
 
     # Find PROJ and SQLite3 for embedded proj.db support
     find_package(PROJ QUIET CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(EXTENSION_SOURCES
     src/raster/band_math.cpp
     src/metadata/raquet_metadata.cpp
     src/table_functions/raquet_table_functions.cpp
+    src/table_functions/merge_bands.cpp
 )
 
 # Find zlib for gzip decompression

--- a/README.md
+++ b/README.md
@@ -306,14 +306,14 @@ SELECT * FROM raquet_merge_bands(LIST<VARCHAR>)
 | (positional) | `LIST<VARCHAR>` | List of paths to single-band raquet parquet files. The order of the list determines the output band order (`inputs[0]` → `band_1`, `inputs[1]` → `band_2`, ...). Each input must contain exactly one band column named `band_1`. |
 
 **Validated at bind time across inputs** (mismatch raises `InvalidInputException`):
-`version`, `compression`, `block_resolution` / `pixel_resolution`, `bounds`, `width`, `height`,
-`minresolution` / `maxresolution`, `block_width` / `block_height`, top-level `dtype`, and the
-top-level `nodata` field. Per-band fields (stats, nodata as quoted strings inside `bands[i]`)
-are propagated from each input.
+`compression`, `crs`, `block_width`, `block_height`, `min_zoom`, `max_zoom`, `bounds`,
+`width`, `height`, and `bands[0].type`. Each input must be single-band; multi-band
+inputs are rejected with a clear error. Per-band fields (stats, colorinterp, colortable,
+nodata, description) are propagated from each input into the merged `bands[i]`.
 
 **Output:**
 - `block` (UBIGINT), `metadata` (VARCHAR), `band_1` ... `band_N` (BLOB) — same shape as `read_raster()` output, ready for `COPY ... TO 'merged.parquet'` or direct `read_raquet()`.
-- The metadata row at `block=0` has the merged metadata. `num_blocks` is recomputed as the count of distinct blocks where any input had data, plus one for the metadata row.
+- The metadata row at `block=0` carries the merged metadata in the same format as the inputs (v0.1.0 inputs produce a v0.1.0 merged metadata; v0.5.0 inputs produce a v0.5.0 merged metadata). `num_blocks` is recomputed as the count of distinct block IDs in the union of all inputs' data rows.
 
 **How the join works:** an internal DuckDB connection runs a parallel hash-join across the inputs on the `block` column (full outer over the data rows of every input). Tiles where only a subset of inputs had data emit `NULL` BLOBs in the columns whose input lacked that block.
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,13 @@ SELECT * FROM read_raster(file, [named parameters...])
 | `zoom_strategy` | `VARCHAR` | `'auto'` | Zoom selection: `auto` (round), `lower` (floor, coarser), `upper` (ceil, finer) |
 | `format` | `VARCHAR` | `'v0.5.0'` | Metadata format: `'v0.5.0'` (spec) or `'v0'` (legacy v0.1.0 shape, drop-in compatible with Python `raster-loader 0.9.1` output — adds `quantiles`, `top_values`, per-band `nodata`, `stats.version` over the bare v0.1.0 spec) |
 | `approx` | `BOOLEAN` | `true` | Use GDAL's `approxOK=TRUE` overview-based statistics for the basic per-band stats (fast). Set `false` for an exact full-resolution scan. The flag also controls whether `quantiles` and `top_values` are computed from a 1000-pixel sample (approx) or from a full-band histogram (exact). Honoured by both `'v0'` and `'v0.5.0'` output formats |
+| `bands` | `VARCHAR` | `'all'` | Source-band filter: `'all'` (every source band, in source order) or a comma-separated list of 1-based source-band indices, e.g. `'2'`, `'2,4,5'`, `'5,2'` (reordering allowed). Output schema is dense `band_1..band_N` regardless of source indices; the source mapping is preserved in `metadata.bands[i].source_band`. |
+| `sparsity_probe` | `VARCHAR` | `'auto'` | Pre-warp empty-tile detection: `'auto'`, `'on'`, `'off'`. Auto enables the IO probe when bind-time stats show `max(valid_percent across selected bands) < 95%`. `'off'` disables both the geometric pre-check and the IO probe (pre-fix path). On globe-extent rasters with sparse coverage, the probe avoids decompressing thousands of empty tiles before the warp. |
+| `sparsity_probe_size` | `INTEGER` | `32` | Mask buffer dimension (NxN) for the IO probe. Min 4, capped at `block_size`. Smaller values (e.g. 8) are faster but on sparse rasters whose source overviews were built with `gdaladdo -r nearest` they can produce false-positive empty (nearest-resampled overview pixels lose sparse signal). 32 is the empirically-validated balance. |
 
 **Output columns:** `block` (UBIGINT), `metadata` (VARCHAR), `band_1` ... `band_N` (BLOB).
 When `statistics=true`, adds `band_N_count`, `band_N_min`, `band_N_max`, `band_N_sum`, `band_N_mean`, `band_N_stddev` columns.
+When `bands` is used, `N` equals the number of selected bands and the schema is renumbered dense from `band_1` (source-band indices live in metadata, not in column names).
 
 **NetCDF time dimension:** When reading NetCDF files with CF time metadata, the time dimension info
 (`cf:units`, `cf:calendar`) is automatically included in the output metadata JSON.
@@ -253,6 +257,11 @@ When `statistics=true`, adds `band_N_count`, `band_N_min`, `band_N_max`, `band_N
 its own per-thread GDAL handle and pulls work off a shared atomic queue. Phase 2 (overview tiles)
 publishes a staged result queue when the last worker finishes warping, so partial-chunk emission
 across `Execute` calls is safe.
+
+**Debug timing:** set the env var `RAQUET_DEBUG_TIMING=1` (any non-empty value) to emit
+`[raquet-phase] phaseN @ Xs (...)` markers on stderr at every Phase 1 / Phase 2 / Phase 3
+transition. Useful for diagnosing slow conversions; off by default. See the in-source comment block
+above `ReadRasterGlobalState` (or `CLAUDE.md`) for the full state-machine semantics.
 
 **Typical workflow:**
 ```sql
@@ -263,6 +272,24 @@ TO 'output.parquet' (FORMAT parquet);
 -- Then query with read_raquet
 SELECT ST_RasterValue(block, band_1, ST_Point(lon, lat), metadata)
 FROM read_raquet('output.parquet');
+```
+
+**Sparse multi-band rasters (recommended workflow):** for rasters where some bands are
+much sparser than others (e.g. one band has 0.5% valid pixels, another has 60%), filter
+to the meaningful bands with `bands=` to skip the heavy ones. For very large multi-band
+rasters that exceed available memory when converting all bands together, use per-band
+conversion via `bands='1'`, `bands='2'`, ... and merge afterwards (a future
+`raquet_merge_bands` table function will handle the metadata-merge automatically;
+in the meantime, see `duckdb-raquet-scripts-and-tests/scripts/convert_raster.sh` for the
+wrapper).
+```sql
+-- Convert only bands 2, 4, 5 (skip the all-nearly-empty bands 1, 3)
+COPY (
+    SELECT * FROM read_raster('input.tif',
+        bands='2,4,5',
+        sparsity_probe='auto',
+        block_size=512)
+) TO 'output.parquet' (FORMAT parquet);
 ```
 
 ### Validation

--- a/README.md
+++ b/README.md
@@ -277,11 +277,9 @@ FROM read_raquet('output.parquet');
 **Sparse multi-band rasters (recommended workflow):** for rasters where some bands are
 much sparser than others (e.g. one band has 0.5% valid pixels, another has 60%), filter
 to the meaningful bands with `bands=` to skip the heavy ones. For very large multi-band
-rasters that exceed available memory when converting all bands together, use per-band
-conversion via `bands='1'`, `bands='2'`, ... and merge afterwards (a future
-`raquet_merge_bands` table function will handle the metadata-merge automatically;
-in the meantime, see `duckdb-raquet-scripts-and-tests/scripts/convert_raster.sh` for the
-wrapper).
+rasters that exceed available memory when converting all bands together, convert each
+band separately with `bands='1'`, `bands='2'`, ... then stitch the per-band raquets
+together with `raquet_merge_bands` (see below).
 ```sql
 -- Convert only bands 2, 4, 5 (skip the all-nearly-empty bands 1, 3)
 COPY (
@@ -291,6 +289,58 @@ COPY (
         block_size=512)
 ) TO 'output.parquet' (FORMAT parquet);
 ```
+
+### raquet_merge_bands (Combine single-band raquets into a multi-band raquet)
+
+Joins a list of single-band raquet parquet files into one multi-band raquet, by `block`.
+The output schema is dense `band_1..band_N` in the order the inputs are passed; the merged
+metadata composes per-band stats/nodata from each input and renumbers `name` and
+`source_band` to match the output position.
+
+```sql
+SELECT * FROM raquet_merge_bands(LIST<VARCHAR>)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| (positional) | `LIST<VARCHAR>` | List of paths to single-band raquet parquet files. The order of the list determines the output band order (`inputs[0]` → `band_1`, `inputs[1]` → `band_2`, ...). Each input must contain exactly one band column named `band_1`. |
+
+**Validated at bind time across inputs** (mismatch raises `InvalidInputException`):
+`version`, `compression`, `block_resolution` / `pixel_resolution`, `bounds`, `width`, `height`,
+`minresolution` / `maxresolution`, `block_width` / `block_height`, top-level `dtype`, and the
+top-level `nodata` field. Per-band fields (stats, nodata as quoted strings inside `bands[i]`)
+are propagated from each input.
+
+**Output:**
+- `block` (UBIGINT), `metadata` (VARCHAR), `band_1` ... `band_N` (BLOB) — same shape as `read_raster()` output, ready for `COPY ... TO 'merged.parquet'` or direct `read_raquet()`.
+- The metadata row at `block=0` has the merged metadata. `num_blocks` is recomputed as the count of distinct blocks where any input had data, plus one for the metadata row.
+
+**How the join works:** an internal DuckDB connection runs a parallel hash-join across the inputs on the `block` column (full outer over the data rows of every input). Tiles where only a subset of inputs had data emit `NULL` BLOBs in the columns whose input lacked that block.
+
+**Typical workflow:**
+```sql
+-- 1. Convert each band separately (memory-efficient for huge multi-band rasters)
+COPY (SELECT * FROM read_raster('big.tif', bands='1', block_size=512))
+  TO 'b1.parquet' (FORMAT parquet);
+COPY (SELECT * FROM read_raster('big.tif', bands='2', block_size=512))
+  TO 'b2.parquet' (FORMAT parquet);
+COPY (SELECT * FROM read_raster('big.tif', bands='3', block_size=512))
+  TO 'b3.parquet' (FORMAT parquet);
+
+-- 2. Merge the per-band parquets (fast — pure metadata + parallel hash join)
+COPY (
+    SELECT * FROM raquet_merge_bands(['b1.parquet', 'b2.parquet', 'b3.parquet'])
+) TO 'merged.parquet' (FORMAT parquet);
+
+-- 3. Drop a band, reorder, or pick a subset — just change the input list
+COPY (
+    SELECT * FROM raquet_merge_bands(['b2.parquet', 'b3.parquet'])
+) TO 'merged_no_b1.parquet' (FORMAT parquet);
+```
+
+**Notes:**
+- `source_band` in the output metadata always equals the output position (`i+1`); the *original* source-band index from each input is overwritten on merge. If you need to preserve the original mapping, record it externally before merging.
+- `raquet_merge_bands` does not re-run sparsity filtering — the input rows are taken as-is. If an input contains tiles that are entirely nodata for that band, those tiles will appear in the merged output (with non-null BLOBs) unless filtering happened during the per-band `read_raster` step.
 
 ### Validation
 

--- a/src/include/band_stats.hpp
+++ b/src/include/band_stats.hpp
@@ -28,7 +28,7 @@ namespace raquet {
 // histogram of the full band — exact for fixed-bucket integer dtypes
 // (uint8/int8/uint16/int16), and exact-up-to-bin-width for wider
 // integer / float dtypes.
-struct V01BandStatsResult {
+struct BandStatsResult {
     int64_t count = 0;
     double  min = 0.0;
     double  max = 0.0;
@@ -50,7 +50,7 @@ struct V01BandStatsResult {
 // false`, GDAL does a full-resolution scan AND we run a streaming
 // pass over the band to build a histogram for exact quantiles /
 // top_values.
-V01BandStatsResult compute_v01_band_stats(
+BandStatsResult compute_band_stats(
     GDALRasterBandH band,
     int raster_width, int raster_height,
     double nodata, bool has_nodata,

--- a/src/include/merge_bands.hpp
+++ b/src/include/merge_bands.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// Registers the `raquet_merge_bands(LIST<VARCHAR>)` table function.
+//
+// Takes a list of single-band raquet parquet paths and returns the
+// merged multi-band raquet content (one metadata row at block=0 with
+// composed multi-band metadata, plus joined data rows where each input's
+// band_1 column maps to the corresponding output column band_i).
+//
+// Validates spatial-frame compatibility across inputs at bind time
+// (version, block geometry, pyramid range, bounds, dimensions, dtype,
+// compression). Mismatches raise InvalidInputException.
+//
+// The data join is delegated to DuckDB's parallel hash join via an
+// internal Connection — this function is mostly orchestration and
+// metadata composition.
+void RegisterMergeBandsFunction(ExtensionLoader &loader);
+
+}  // namespace duckdb

--- a/src/include/raquet_metadata.hpp
+++ b/src/include/raquet_metadata.hpp
@@ -967,6 +967,19 @@ inline RaquetMetadata parse_metadata(const std::string &json) {
     meta.width = extract_json_int(json, "width", 0);
     meta.height = extract_json_int(json, "height", 0);
 
+    // Bounds: [W, S, E, N] in WGS84 — top-level in both v0.1.0 and v0.5.0.
+    {
+        std::vector<double> b;
+        std::vector<bool> hb;
+        extract_json_number_array(json, "bounds", b, hb);
+        if (b.size() >= 4) {
+            meta.bounds_minlon = b[0];
+            meta.bounds_minlat = b[1];
+            meta.bounds_maxlon = b[2];
+            meta.bounds_maxlat = b[3];
+        }
+    }
+
     parse_bands_full(json, meta.bands, meta.band_info);
 
     // v0.5.0: tile statistics

--- a/src/include/raquet_metadata.hpp
+++ b/src/include/raquet_metadata.hpp
@@ -19,6 +19,11 @@ struct BandInfo {
     double nodata;
     bool has_nodata;
 
+    // 1-based source-band index, preserved when the user filters bands via
+    // read_raster(..., bands='2,4,5'). Defaults to 0, which means "not
+    // tracked / single-band-style"; serializers may omit the field when 0.
+    int source_band = 0;
+
     // Extended band metadata (v0.3.0+)
     std::string description;
     std::string unit;
@@ -353,6 +358,15 @@ struct RaquetMetadata {
             const auto &bi = band_info[i];
             json += "{\"name\":\"" + bi.name + "\"";
             json += ",\"type\":\"" + bi.type + "\"";
+            // Source-band index — only emitted when set (i.e., when the
+            // user filtered bands via bands=). Preserves the mapping from
+            // the dense output band_N back to the original source band.
+            if (bi.source_band > 0) {
+                json += ",\"source_band\":" + std::to_string(bi.source_band);
+                if (!bi.description.empty()) {
+                    json += ",\"source_description\":\"" + bi.description + "\"";
+                }
+            }
             json += ",\"nodata\":" + nodata_to_json_v0_band(bi);
             json += ",\"colorinterp\":";
             if (bi.colorinterp.empty()) {
@@ -422,6 +436,12 @@ struct RaquetMetadata {
             const auto &bi = band_info[i];
             json += "{\"name\":\"" + bi.name + "\"";
             json += ",\"type\":\"" + bi.type + "\"";
+            // Source-band index — only emitted when the user filtered
+            // bands. Preserves the mapping from output band_N back to
+            // the original source band index.
+            if (bi.source_band > 0) {
+                json += ",\"source_band\":" + std::to_string(bi.source_band);
+            }
             if (bi.has_nodata) {
                 if (std::isnan(bi.nodata)) {
                     json += ",\"nodata\":\"NaN\"";

--- a/src/raquet_extension.cpp
+++ b/src/raquet_extension.cpp
@@ -27,6 +27,7 @@ void RegisterClipFunctions(ExtensionLoader &loader);
 void RegisterBandMathFunctions(ExtensionLoader &loader);
 void RegisterMetadataFunctions(ExtensionLoader &loader);
 void RegisterRaquetTableFunctions(ExtensionLoader &loader);
+void RegisterMergeBandsFunction(ExtensionLoader &loader);
 
 // Table macro definitions for read_raquet with spatial filtering overloads
 // v0.3.0 format: metadata is in a row where block=0, data rows have block!=0
@@ -363,6 +364,7 @@ static void LoadInternal(ExtensionLoader &loader) {
     RegisterBandMathFunctions(loader);
     RegisterMetadataFunctions(loader);
     RegisterRaquetTableFunctions(loader);
+    RegisterMergeBandsFunction(loader);
 
     // Register read_raquet table macro with all overloads
     auto macro_info = CreateReadRaquetMacroInfo();

--- a/src/raster/band_stats.cpp
+++ b/src/raster/band_stats.cpp
@@ -1,6 +1,6 @@
 #ifdef RAQUET_HAS_GDAL
 
-#include "band_stats_v01.hpp"
+#include "band_stats.hpp"
 
 #include <gdal.h>
 #include <cpl_error.h>
@@ -70,7 +70,7 @@ static bool extract_basic_stats(
     GDALRasterBandH band,
     int raster_width, int raster_height,
     bool approx,
-    V01BandStatsResult &out) {
+    BandStatsResult &out) {
 
     double smin = 0, smax = 0, smean = 0, sstddev = 0;
     CPLErr err = GDALComputeRasterStatistics(
@@ -338,14 +338,14 @@ static void quantiles_and_top_values_from_histogram(
 // ─────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────
-V01BandStatsResult compute_v01_band_stats(
+BandStatsResult compute_band_stats(
     GDALRasterBandH band,
     int raster_width, int raster_height,
     double nodata, bool has_nodata,
     GDALDataType dtype,
     bool approx) {
 
-    V01BandStatsResult r;
+    BandStatsResult r;
     r.version = kVersionTag;
     if (!band || raster_width <= 0 || raster_height <= 0) {
         return r;

--- a/src/raster/read_raster.cpp
+++ b/src/raster/read_raster.cpp
@@ -441,42 +441,58 @@ static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
 // ─────────────────────────────────────────────
 // Helper: Check if a tile is entirely nodata (empty)
 // ─────────────────────────────────────────────
-static bool IsTileEmpty(GDALDatasetH ds, double nodata, bool has_nodata) {
-    if (!has_nodata) return false;
+// A tile is empty only if EVERY band is fully nodata. Short-circuits on the
+// first non-nodata pixel found in any band. Each band uses its own nodata
+// value (per-band nodata is allowed by GDAL). If any band lacks a defined
+// nodata, or the read fails, returns false (keep the tile) — we cannot
+// prove emptiness and dropping the tile would silently lose valid data.
+static bool IsTileEmpty(GDALDatasetH ds,
+                         const std::vector<double> &band_nodatas,
+                         const std::vector<bool> &band_has_nodata) {
+    int band_count = GDALGetRasterCount(ds);
+    if (band_count == 0) return false;
 
-    int width = GDALGetRasterXSize(ds);
+    if (static_cast<int>(band_has_nodata.size()) < band_count) return false;
+    for (int i = 0; i < band_count; i++) {
+        if (!band_has_nodata[i]) return false;
+    }
+
+    int width  = GDALGetRasterXSize(ds);
     int height = GDALGetRasterYSize(ds);
-    GDALRasterBandH band = GDALGetRasterBand(ds, 1);
-
-    // Read first band and check if all pixels are nodata
     size_t num_pixels = static_cast<size_t>(width) * height;
-    GDALDataType dt = GDALGetRasterDataType(band);
-    int dt_size = GDALGetDataTypeSizeBytes(dt);
 
-    std::vector<uint8_t> buf(num_pixels * dt_size);
-    CPLErr err = GDALRasterIO(band, GF_Read, 0, 0, width, height,
-                               buf.data(), width, height, dt, 0, 0);
-    if (err != CE_None) return false;
+    std::vector<uint8_t> buf;
+    for (int b = 1; b <= band_count; b++) {
+        GDALRasterBandH band = GDALGetRasterBand(ds, b);
+        GDALDataType dt = GDALGetRasterDataType(band);
+        int dt_size = GDALGetDataTypeSizeBytes(dt);
 
-    bool is_nan_nodata = std::isnan(nodata);
+        double nodata = band_nodatas[b - 1];
+        bool is_nan_nodata = std::isnan(nodata);
 
-    for (size_t i = 0; i < num_pixels; i++) {
-        double val = 0;
-        switch (dt) {
-            case GDT_Byte:    val = static_cast<double>(buf[i]); break;
-            case GDT_Int16:   { int16_t v; memcpy(&v, buf.data() + i * 2, 2); val = v; break; }
-            case GDT_UInt16:  { uint16_t v; memcpy(&v, buf.data() + i * 2, 2); val = v; break; }
-            case GDT_Int32:   { int32_t v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
-            case GDT_UInt32:  { uint32_t v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
-            case GDT_Float32: { float v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
-            case GDT_Float64: { memcpy(&val, buf.data() + i * 8, 8); break; }
-            default: return false;
-        }
+        buf.assign(num_pixels * dt_size, 0);
+        CPLErr err = GDALRasterIO(band, GF_Read, 0, 0, width, height,
+                                   buf.data(), width, height, dt, 0, 0);
+        if (err != CE_None) return false;
 
-        if (is_nan_nodata) {
-            if (!std::isnan(val)) return false;
-        } else {
-            if (val != nodata) return false;
+        for (size_t i = 0; i < num_pixels; i++) {
+            double val = 0;
+            switch (dt) {
+                case GDT_Byte:    val = static_cast<double>(buf[i]); break;
+                case GDT_Int8:    { int8_t v; memcpy(&v, buf.data() + i, 1); val = v; break; }
+                case GDT_Int16:   { int16_t v; memcpy(&v, buf.data() + i * 2, 2); val = v; break; }
+                case GDT_UInt16:  { uint16_t v; memcpy(&v, buf.data() + i * 2, 2); val = v; break; }
+                case GDT_Int32:   { int32_t v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
+                case GDT_UInt32:  { uint32_t v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
+                case GDT_Int64:   { int64_t v; memcpy(&v, buf.data() + i * 8, 8); val = static_cast<double>(v); break; }
+                case GDT_UInt64:  { uint64_t v; memcpy(&v, buf.data() + i * 8, 8); val = static_cast<double>(v); break; }
+                case GDT_Float32: { float v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
+                case GDT_Float64: { memcpy(&val, buf.data() + i * 8, 8); break; }
+                default: return false;
+            }
+
+            bool pixel_is_nodata = is_nan_nodata ? std::isnan(val) : (val == nodata);
+            if (!pixel_is_nodata) return false;
         }
     }
     return true;
@@ -1269,7 +1285,7 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
         WarpIntoTile(local, tile_ds, state.source_resampling,
                      state.nodata_value, state.has_nodata);
 
-        bool empty = IsTileEmpty(tile_ds, state.nodata_value, state.has_nodata);
+        bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas, bind_data.band_has_nodata);
 
         if (!empty) {
             auto tile_data = ReadAndCompressBands(
@@ -1408,7 +1424,7 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                              state.nodata_value, state.has_nodata);
             }
 
-            bool empty = IsTileEmpty(tile_ds, state.nodata_value, state.has_nodata);
+            bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas, bind_data.band_has_nodata);
 
             if (!empty) {
                 auto tile_data = ReadAndCompressBands(

--- a/src/raster/read_raster.cpp
+++ b/src/raster/read_raster.cpp
@@ -31,6 +31,8 @@
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <set>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -158,6 +160,14 @@ struct ReadRasterBindData : public TableFunctionData {
     bool sparsity_probe_active = false;     // resolved at bind time
     std::vector<bool> band_is_empty;        // valid_percent <= 0 ⇒ true
 
+    // Band filter — 1-based source-band indices to emit, in output order.
+    // Empty after parsing means "use all source bands"; the post-parse fill
+    // populates 1..raster_band_count in that case so downstream code never
+    // sees an empty selection. Default value of the named parameter is
+    // 'all' (equivalent to omitting the parameter); a comma-separated list
+    // of indices ('2', '2,4,5', '5,2') overrides it.
+    std::vector<int> selected_bands;
+
     // CF time dimension (NetCDF)
     bool has_cf_time = false;
     std::string cf_units_string;        // e.g., "minutes since 1980-01-01 00:00:00"
@@ -264,6 +274,14 @@ struct ReadRasterGlobalState : public GlobalTableFunctionState {
 
     // Whether we need overviews at all
     bool has_overviews = false;
+
+    // Phase-timing instrumentation (debug). Recorded as ns-since-init_start.
+    std::chrono::steady_clock::time_point init_start;
+    std::atomic<int64_t> phase1_first_ns{-1};
+    std::atomic<int64_t> phase1_done_ns{-1};
+    std::atomic<int64_t> phase2_init_ns{-1};
+    std::atomic<int64_t> phase2_staged_ns{-1};
+    std::atomic<int64_t> phase3_done_ns{-1};
 
     idx_t MaxThreads() const override {
         return GlobalTableFunctionState::MAX_THREADS;
@@ -404,6 +422,7 @@ static void EnsureWarpTransformer(ReadRasterLocalState &local,
 
 static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
                           GDALResampleAlg resample, double nodata, bool has_nodata,
+                          const std::vector<int> &selected_bands,
                           int overview_level = -1) {
     GDALDatasetH src_ds = local.src_ds;
     EnsureWarpTransformer(local, tile_ds, overview_level);
@@ -412,12 +431,15 @@ static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
     wo->hSrcDS = src_ds;
     wo->hDstDS = tile_ds;
     wo->eResampleAlg = resample;
-    wo->nBandCount = GDALGetRasterCount(src_ds);
+    // Output band count = selected bands. panSrcBands maps each output band
+    // to the corresponding 1-based source band index; panDstBands is dense
+    // 1..N (the destination tile was created with N = selected.size() bands).
+    wo->nBandCount = static_cast<int>(selected_bands.size());
 
     wo->panSrcBands = static_cast<int *>(CPLMalloc(sizeof(int) * wo->nBandCount));
     wo->panDstBands = static_cast<int *>(CPLMalloc(sizeof(int) * wo->nBandCount));
     for (int i = 0; i < wo->nBandCount; i++) {
-        wo->panSrcBands[i] = i + 1;
+        wo->panSrcBands[i] = selected_bands[i];
         wo->panDstBands[i] = i + 1;
     }
 
@@ -976,6 +998,43 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
             else if (v == "off")  bind_data->sparsity_probe = SparsityProbe::Off;
             else throw InvalidInputException(
                 "sparsity_probe must be 'auto', 'on', or 'off'");
+        } else if (kv.first == "bands") {
+            // 'all' (case-insensitive) or empty → defer to default fill below.
+            // Otherwise: comma-separated list of 1-based source-band indices.
+            auto raw = kv.second.GetValue<string>();
+            auto raw_lower = StringUtil::Lower(raw);
+            auto first = raw_lower.find_first_not_of(" \t");
+            auto last  = raw_lower.find_last_not_of(" \t");
+            if (first != std::string::npos) {
+                raw_lower = raw_lower.substr(first, last - first + 1);
+            } else {
+                raw_lower.clear();
+            }
+            bind_data->selected_bands.clear();
+            if (raw_lower != "all" && !raw_lower.empty()) {
+                std::stringstream ss(raw);
+                std::string tok;
+                while (std::getline(ss, tok, ',')) {
+                    auto a = tok.find_first_not_of(" \t");
+                    auto b = tok.find_last_not_of(" \t");
+                    if (a == std::string::npos) continue;
+                    tok = tok.substr(a, b - a + 1);
+                    if (tok.empty()) continue;
+                    try {
+                        bind_data->selected_bands.push_back(std::stoi(tok));
+                    } catch (...) {
+                        throw InvalidInputException(
+                            "bands: invalid band index '%s' "
+                            "(use 'all' or a comma-separated list of 1-based indices)",
+                            tok);
+                    }
+                }
+                if (bind_data->selected_bands.empty()) {
+                    throw InvalidInputException(
+                        "bands: parsed no indices from '%s' "
+                        "(use 'all' or e.g. '1,2,5')", raw);
+                }
+            }
         }
     }
 
@@ -1005,13 +1064,43 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
         throw InvalidInputException("Raster file has no bands: %s", bind_data->filename);
     }
 
+    // Resolve `bands` filter: if the user didn't specify (or passed 'all'),
+    // populate selected_bands with 1..raster_band_count. Otherwise validate
+    // the user-supplied indices are in range and dedup while preserving
+    // their order (so bands='5,2' yields band_1=src5, band_2=src2).
+    if (bind_data->selected_bands.empty()) {
+        bind_data->selected_bands.reserve(bind_data->raster_band_count);
+        for (int i = 1; i <= bind_data->raster_band_count; i++) {
+            bind_data->selected_bands.push_back(i);
+        }
+    } else {
+        for (int b : bind_data->selected_bands) {
+            if (b < 1 || b > bind_data->raster_band_count) {
+                GDALClose(ds);
+                throw InvalidInputException(
+                    "bands: index %d out of range (1..%d)",
+                    b, bind_data->raster_band_count);
+            }
+        }
+        std::vector<int> dedup;
+        std::set<int> seen;
+        for (int b : bind_data->selected_bands) {
+            if (seen.insert(b).second) dedup.push_back(b);
+        }
+        bind_data->selected_bands = std::move(dedup);
+    }
+
     GDALRasterBandH first_band = GDALGetRasterBand(ds, 1);
     bind_data->gdal_dtype = GDALGetRasterDataType(first_band);
     bind_data->raquet_dtype = GDALTypeToRaquetType(bind_data->gdal_dtype);
     bind_data->dtype_bytes = GDALTypeSize(bind_data->gdal_dtype);
 
-    // Per-band metadata
-    for (int b = 1; b <= bind_data->raster_band_count; b++) {
+    // Per-band metadata, indexed by output position (0-based dense). Each
+    // entry pulls from the source band at selected_bands[idx]. After this
+    // loop, all the band_* vectors have selected_bands.size() entries and
+    // downstream code iterates them without caring about source indices.
+    for (size_t idx = 0; idx < bind_data->selected_bands.size(); idx++) {
+        int b = bind_data->selected_bands[idx];  // 1-based source index
         GDALRasterBandH band = GDALGetRasterBand(ds, b);
         int has_nd = 0;
         double nd = GDALGetRasterNoDataValue(band, &has_nd);
@@ -1093,9 +1182,12 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
     // per-band cull in IsTileEmpty can run regardless of probe state.
     {
         constexpr double SPARSITY_AUTO_VALID_PCT_CUTOFF = 95.0;
-        bind_data->band_is_empty.assign(bind_data->raster_band_count, false);
+        // Iterate selected (output) bands; band_stats has selected.size()
+        // entries indexed by output position.
+        const int out_band_count = static_cast<int>(bind_data->selected_bands.size());
+        bind_data->band_is_empty.assign(out_band_count, false);
         double max_valid_pct = -1.0;
-        for (int i = 0; i < bind_data->raster_band_count; i++) {
+        for (int i = 0; i < out_band_count; i++) {
             const auto &st = bind_data->band_stats[i];
             if (!st.has_stats) continue;
             if (st.valid_percent <= 0.0) bind_data->band_is_empty[i] = true;
@@ -1164,6 +1256,20 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
                 }
             }
         }
+    }
+
+    // Disallow band filtering on time-series sources. CF-time mode emits
+    // one row per band per tile and uses cf_time_values[band_idx] as the
+    // time value — filtering bands would silently reorder/drop time
+    // dimensions. Out of scope for this feature; raise an explicit error.
+    if (bind_data->has_cf_time &&
+        static_cast<int>(bind_data->selected_bands.size()) !=
+            bind_data->raster_band_count) {
+        GDALClose(ds);
+        throw InvalidInputException(
+            "bands filter is not supported on time-series rasters "
+            "(CF time dimension detected); convert all bands or strip "
+            "the time dimension upstream");
     }
 
     // CRS detection
@@ -1294,12 +1400,16 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
     names.push_back("metadata");
     return_types.push_back(LogicalType::VARCHAR);
 
-    // Band columns
+    // Band columns. Schema follows raster_loader convention: dense
+    // band_1..band_N where N is the number of selected bands. Source-band
+    // indices are not visible in column names; they're preserved in the
+    // metadata JSON (bands[i].source_band) for downstream tools.
+    const int out_band_count = static_cast<int>(bind_data->selected_bands.size());
     if (bind_data->band_layout == "interleaved") {
         names.push_back("pixels");
         return_types.push_back(LogicalType::BLOB);
     } else {
-        for (int b = 0; b < bind_data->raster_band_count; b++) {
+        for (int b = 0; b < out_band_count; b++) {
             names.push_back("band_" + std::to_string(b + 1));
             return_types.push_back(LogicalType::BLOB);
         }
@@ -1307,7 +1417,7 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
 
     // Statistics columns (optional)
     if (bind_data->statistics) {
-        for (int b = 0; b < bind_data->raster_band_count; b++) {
+        for (int b = 0; b < out_band_count; b++) {
             std::string prefix = "band_" + std::to_string(b + 1) + "_";
             names.push_back(prefix + "count");  return_types.push_back(LogicalType::BIGINT);
             names.push_back(prefix + "min");    return_types.push_back(LogicalType::DOUBLE);
@@ -1350,6 +1460,7 @@ static unique_ptr<GlobalTableFunctionState> ReadRasterInitGlobal(ClientContext &
                                                                   TableFunctionInitInput &input) {
     auto &bind_data = input.bind_data->Cast<ReadRasterBindData>();
     auto state = make_uniq<ReadRasterGlobalState>();
+    state->init_start = std::chrono::steady_clock::now();
 
     state->source_resampling = bind_data.resampling;
     state->has_overviews = (bind_data.min_zoom < bind_data.max_zoom);
@@ -1485,14 +1596,29 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             my_idx = state.next_tile_idx++;
         }
 
+        // [phase-timing] mark the first Phase 1 tile pull
+        if (state.phase1_first_ns.load(std::memory_order_acquire) < 0) {
+            int64_t expected = -1;
+            int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::steady_clock::now() - state.init_start).count();
+            if (state.phase1_first_ns.compare_exchange_strong(expected, now_ns)) {
+                fprintf(stderr, "[raquet-phase] phase1_first @ %.3fs (native_tiles=%zu, threads=%d)\n",
+                        now_ns / 1e9, state.native_tiles.size(),
+                        static_cast<int>(state.MaxThreads()));
+                fflush(stderr);
+            }
+        }
+
         auto &tile = state.native_tiles[my_idx];
 
-        // Create tile dataset and warp
+        // Create tile dataset and warp. Destination band count is the
+        // selected-band count (the band filter), not the source's raw
+        // raster_band_count.
         std::string tile_path;
         GDALDatasetH tile_ds = CreateTileDataset(
             local.gtiff_driver, local.web_mercator_wkt,
             tile, bind_data.block_size,
-            bind_data.raster_band_count, bind_data.gdal_dtype,
+            static_cast<int>(bind_data.selected_bands.size()), bind_data.gdal_dtype,
             state.nodata_value, state.has_nodata, tile_path);
 
         // Pre-warp emptiness checks: build the transformer first so both
@@ -1516,7 +1642,8 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
 
         if (!pre_warp_skip) {
             WarpIntoTile(local, tile_ds, state.source_resampling,
-                         state.nodata_value, state.has_nodata);
+                         state.nodata_value, state.has_nodata,
+                         bind_data.selected_bands);
 
             bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas,
                                      bind_data.band_has_nodata,
@@ -1586,6 +1713,22 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                 } else {
                     state.overview_results.reserve(state.overview_frames.size());
                 }
+                {
+                    int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::steady_clock::now() - state.init_start).count();
+                    state.phase1_done_ns.store(now_ns, std::memory_order_release);
+                    state.phase2_init_ns.store(now_ns, std::memory_order_release);
+                    int64_t p1_first = state.phase1_first_ns.load(std::memory_order_acquire);
+                    fprintf(stderr,
+                        "[raquet-phase] phase1_done @ %.3fs (phase1_wall=%.3fs, "
+                        "native_tiles=%zu, emitted=%d, overview_frames=%zu)\n",
+                        now_ns / 1e9,
+                        (now_ns - p1_first) / 1e9,
+                        state.native_tiles.size(),
+                        state.total_blocks.load(),
+                        state.overview_frames.size());
+                    fflush(stderr);
+                }
                 state.phase2_init_done.store(true, std::memory_order_release);
                 // Wake siblings waiting on phase2_init_done, plus any thread
                 // already past staging that's parked on phase2_staged (the
@@ -1617,7 +1760,7 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             GDALDatasetH tile_ds = CreateTileDataset(
                 local.gtiff_driver, local.web_mercator_wkt,
                 frame.tile, bind_data.block_size,
-                bind_data.raster_band_count, bind_data.gdal_dtype,
+                static_cast<int>(bind_data.selected_bands.size()), bind_data.gdal_dtype,
                 state.nodata_value, state.has_nodata, ovr_path);
 
             // Decide the source overview level upfront so the pre-warp
@@ -1667,13 +1810,15 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                     // and the warper reprojects from the chosen overview
                     // just as it would from base.
                     WarpIntoTile(local, tile_ds, GRA_NearestNeighbour,
-                                 state.nodata_value, state.has_nodata, chosen_overview);
+                                 state.nodata_value, state.has_nodata,
+                                 bind_data.selected_bands, chosen_overview);
                 } else {
                     // Fallback: warp from base resolution. Honour the user's
                     // resampling= named param (default GRA_NearestNeighbour)
                     // so Phase 2 fallback is consistent with Phase 1.
                     WarpIntoTile(local, tile_ds, state.source_resampling,
-                                 state.nodata_value, state.has_nodata);
+                                 state.nodata_value, state.has_nodata,
+                                 bind_data.selected_bands);
                 }
 
                 bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas,
@@ -1702,6 +1847,21 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             if (completed >= total_frames) {
                 // We finished the last overview tile — publish the staged
                 // queue and wake any post-staging waiter parked on wait_cv.
+                {
+                    int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::steady_clock::now() - state.init_start).count();
+                    state.phase2_staged_ns.store(now_ns, std::memory_order_release);
+                    int64_t p2_init = state.phase2_init_ns.load(std::memory_order_acquire);
+                    fprintf(stderr,
+                        "[raquet-phase] phase2_staged @ %.3fs (phase2_wall=%.3fs, "
+                        "overview_frames=%zu, staged=%zu, total_blocks=%d)\n",
+                        now_ns / 1e9,
+                        (now_ns - p2_init) / 1e9,
+                        total_frames,
+                        state.overview_results.size(),
+                        state.total_blocks.load());
+                    fflush(stderr);
+                }
                 state.phase2_staged.store(true, std::memory_order_release);
                 { std::lock_guard<std::mutex> lk(state.wait_mutex); }
                 state.wait_cv.notify_all();
@@ -1757,6 +1917,19 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
     // ── Phase 3: Emit metadata row (exactly once, thread-safe) ──
     bool expected = false;
     if (state.metadata_emitted.compare_exchange_strong(expected, true)) {
+        {
+            int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::steady_clock::now() - state.init_start).count();
+            state.phase3_done_ns.store(now_ns, std::memory_order_release);
+            int64_t p2_staged = state.phase2_staged_ns.load(std::memory_order_acquire);
+            fprintf(stderr,
+                "[raquet-phase] phase3_metadata @ %.3fs (drain+meta_wall=%.3fs, "
+                "total_blocks=%d)\n",
+                now_ns / 1e9,
+                (now_ns - p2_staged) / 1e9,
+                state.total_blocks.load());
+            fflush(stderr);
+        }
         // Build metadata
         raquet::RaquetMetadata meta;
         meta.file_format = "raquet";
@@ -1792,11 +1965,16 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             meta.time_calendar = bind_data.cf_calendar;
         }
 
-        // Band info with extended metadata
-        for (int b = 0; b < bind_data.raster_band_count; b++) {
+        // Band info with extended metadata. Indexed by output (selected)
+        // band position; the source-band index for each entry is preserved
+        // in BandInfo.source_band so downstream tools can map output
+        // band_N back to its source.
+        const int out_band_count = static_cast<int>(bind_data.selected_bands.size());
+        for (int b = 0; b < out_band_count; b++) {
             raquet::BandInfo bi;
             bi.name = "band_" + std::to_string(b + 1);
             bi.type = bind_data.raquet_dtype;
+            bi.source_band = bind_data.selected_bands[b];
             if (bind_data.band_has_nodata[b]) {
                 bi.nodata = bind_data.band_nodatas[b];
                 bi.has_nodata = true;
@@ -1842,7 +2020,9 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
         col++;
 
         // Band columns are NULL for metadata row
-        int num_band_cols = (bind_data.band_layout == "interleaved") ? 1 : bind_data.raster_band_count;
+        int num_band_cols = (bind_data.band_layout == "interleaved")
+                                ? 1
+                                : static_cast<int>(bind_data.selected_bands.size());
         for (int b = 0; b < num_band_cols; b++) {
             FlatVector::SetNull(output.data[col], row_count, true);
             col++;
@@ -1850,7 +2030,8 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
 
         // Stats columns are NULL for metadata row
         if (bind_data.statistics) {
-            for (int b = 0; b < bind_data.raster_band_count * 6; b++) {
+            int stats_cols = static_cast<int>(bind_data.selected_bands.size()) * 6;
+            for (int b = 0; b < stats_cols; b++) {
                 FlatVector::SetNull(output.data[col], row_count, true);
                 col++;
             }
@@ -1892,6 +2073,7 @@ void RegisterReadRaster(ExtensionLoader &loader) {
     func.named_parameters["format"] = LogicalType::VARCHAR;
     func.named_parameters["approx"] = LogicalType::BOOLEAN;
     func.named_parameters["sparsity_probe"] = LogicalType::VARCHAR;
+    func.named_parameters["bands"] = LogicalType::VARCHAR;
     func.cardinality = ReadRasterCardinality;
 
     loader.RegisterFunction(func);

--- a/src/raster/read_raster.cpp
+++ b/src/raster/read_raster.cpp
@@ -3,7 +3,7 @@
 #include "read_raster.hpp"
 #include "band_encoder.hpp"
 #include "band_decoder.hpp"
-#include "band_stats_v01.hpp"
+#include "band_stats.hpp"
 #include "raquet_metadata.hpp"
 #include "quadbin.hpp"
 #include "proj_embed.hpp"
@@ -1228,26 +1228,26 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
         // dicts when the band is too sparse — emitted as `{}` by the
         // serializer.
         raquet::BandInfo::Stats st;
-        auto v01 = raquet::compute_v01_band_stats(
+        auto stats = raquet::compute_band_stats(
             band,
             bind_data->raster_width, bind_data->raster_height,
             has_nd ? nd : 0.0, has_nd != 0,
             bind_data->gdal_dtype,
             bind_data->approx_stats);
-        if (v01.has_stats) {
-            st.count         = v01.count;
-            st.min           = v01.min;
-            st.max           = v01.max;
-            st.mean          = v01.mean;
-            st.stddev        = v01.stddev;
-            st.sum           = v01.sum;
-            st.sum_squares   = v01.sum_squares;
-            st.valid_percent = v01.valid_percent;
-            st.approximated  = v01.approximated;
+        if (stats.has_stats) {
+            st.count         = stats.count;
+            st.min           = stats.min;
+            st.max           = stats.max;
+            st.mean          = stats.mean;
+            st.stddev        = stats.stddev;
+            st.sum           = stats.sum;
+            st.sum_squares   = stats.sum_squares;
+            st.valid_percent = stats.valid_percent;
+            st.approximated  = stats.approximated;
             st.has_stats     = true;
-            st.version       = std::move(v01.version);
-            st.quantiles     = std::move(v01.quantiles);
-            st.top_values    = std::move(v01.top_values);
+            st.version       = std::move(stats.version);
+            st.quantiles     = std::move(stats.quantiles);
+            st.top_values    = std::move(stats.top_values);
         }
         bind_data->band_stats.push_back(st);
     }

--- a/src/raster/read_raster.cpp
+++ b/src/raster/read_raster.cpp
@@ -93,6 +93,14 @@ struct RasterTile {
 };
 
 // ─────────────────────────────────────────────
+// User-controlled mode for the pre-warp sparsity probe.
+// Auto enables the probe only when bind-time stats indicate the raster is
+// non-trivially sparse; On forces it; Off disables both the probe and the
+// always-free geometric pre-check, restoring pre-patch behavior.
+// ─────────────────────────────────────────────
+enum class SparsityProbe { Auto, On, Off };
+
+// ─────────────────────────────────────────────
 // Bind data — holds everything discovered at bind time
 // ─────────────────────────────────────────────
 struct ReadRasterBindData : public TableFunctionData {
@@ -144,6 +152,11 @@ struct ReadRasterBindData : public TableFunctionData {
     std::string overviews = "auto";
     std::string zoom_strategy = "auto"; // auto, lower, upper
     std::string output_format = "v0.5.0"; // v0 or v0.5.0
+
+    // Sparsity-aware tile pipeline
+    SparsityProbe sparsity_probe = SparsityProbe::Auto;
+    bool sparsity_probe_active = false;     // resolved at bind time
+    std::vector<bool> band_is_empty;        // valid_percent <= 0 ⇒ true
 
     // CF time dimension (NetCDF)
     bool has_cf_time = false;
@@ -356,15 +369,16 @@ static GDALDatasetH CreateTileDataset(GDALDriverH driver, const char *wkt_3857,
 // geotransform is updated via GDALSetGenImgProjTransformerDstGeoTransform
 // and the warp uses the cached object.
 // ─────────────────────────────────────────────
-static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
-                          GDALResampleAlg resample, double nodata, bool has_nodata,
-                          int overview_level = -1) {
+// Build (or refresh) the per-thread warp transformer for `tile_ds` at the
+// requested source overview level. Same-level reuse just retargets the dst
+// geotransform — cheap. Different overview levels rebuild from scratch.
+// Lifted out of WarpIntoTile so the pre-warp emptiness checks can call it
+// before any warping happens.
+static void EnsureWarpTransformer(ReadRasterLocalState &local,
+                                   GDALDatasetH tile_ds,
+                                   int overview_level) {
     GDALDatasetH src_ds = local.src_ds;
-
     if (!local.warp_transformer || local.warp_transformer_overview_level != overview_level) {
-        // (Re)build the transformer. OVERVIEW_LEVEL belongs on the
-        // transformer (consumed by GDALCreateGenImgProjTransformer2 as
-        // SRC_OVERVIEW_LEVEL), not on GDALWarpOptions::papszWarpOptions.
         if (local.warp_transformer) {
             GDALDestroyGenImgProjTransformer(local.warp_transformer);
             local.warp_transformer = nullptr;
@@ -382,14 +396,17 @@ static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
         }
         local.warp_transformer_overview_level = overview_level;
     } else {
-        // Same overview level — reuse the cached transformer, just point
-        // it at the new tile's geotransform. Source CRS and source
-        // geotransform haven't changed; destination CRS hasn't changed
-        // either (every tile_ds is in EPSG:3857 with identical WKT).
         double dst_gt[6];
         GDALGetGeoTransform(tile_ds, dst_gt);
         GDALSetGenImgProjTransformerDstGeoTransform(local.warp_transformer, dst_gt);
     }
+}
+
+static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
+                          GDALResampleAlg resample, double nodata, bool has_nodata,
+                          int overview_level = -1) {
+    GDALDatasetH src_ds = local.src_ds;
+    EnsureWarpTransformer(local, tile_ds, overview_level);
 
     GDALWarpOptions *wo = GDALCreateWarpOptions();
     wo->hSrcDS = src_ds;
@@ -439,6 +456,172 @@ static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
 }
 
 // ─────────────────────────────────────────────
+// Helper: Decode a single pixel from a typed buffer into a double.
+// Returns false on unsupported dtype (caller should bail conservatively).
+// Shared by IsTileEmpty and IsSourceWindowEmpty.
+// ─────────────────────────────────────────────
+static bool DecodePixel(GDALDataType dt, const uint8_t *buf, size_t i, double &val) {
+    switch (dt) {
+        case GDT_Byte:    val = static_cast<double>(buf[i]); return true;
+        case GDT_Int8:    { int8_t v; memcpy(&v, buf + i, 1); val = v; return true; }
+        case GDT_Int16:   { int16_t v; memcpy(&v, buf + i * 2, 2); val = v; return true; }
+        case GDT_UInt16:  { uint16_t v; memcpy(&v, buf + i * 2, 2); val = v; return true; }
+        case GDT_Int32:   { int32_t v; memcpy(&v, buf + i * 4, 4); val = v; return true; }
+        case GDT_UInt32:  { uint32_t v; memcpy(&v, buf + i * 4, 4); val = v; return true; }
+        case GDT_Int64:   { int64_t v; memcpy(&v, buf + i * 8, 8); val = static_cast<double>(v); return true; }
+        case GDT_UInt64:  { uint64_t v; memcpy(&v, buf + i * 8, 8); val = static_cast<double>(v); return true; }
+        case GDT_Float32: { float v; memcpy(&v, buf + i * 4, 4); val = v; return true; }
+        case GDT_Float64: { memcpy(&val, buf + i * 8, 8); return true; }
+        default: return false;
+    }
+}
+
+// ─────────────────────────────────────────────
+// Helper: Compute the source-pixel window covered by a destination tile.
+// Back-projects the 4 corners (with `margin_px` slack to cover the
+// resampling kernel), clips to source raster bounds, and writes the
+// result into wx0/wy0/wx1/wy1. Returns false on transformer failure.
+// `outside_source` is set to true when the inflated bbox falls entirely
+// off the source raster (caller can short-circuit to "skip tile").
+// ─────────────────────────────────────────────
+static bool BackProjectTileToSource(GDALDatasetH src_ds, void *transformer,
+                                     int dst_tile_size, int margin_px,
+                                     int &wx0, int &wy0, int &wx1, int &wy1,
+                                     bool &outside_source) {
+    outside_source = false;
+    if (!transformer) return false;
+
+    double xs[4] = {0.0, (double)dst_tile_size, 0.0, (double)dst_tile_size};
+    double ys[4] = {0.0, 0.0, (double)dst_tile_size, (double)dst_tile_size};
+    double zs[4] = {0.0, 0.0, 0.0, 0.0};
+    int    ok[4] = {0, 0, 0, 0};
+    if (!GDALGenImgProjTransform(transformer, /*bDstToSrc=*/TRUE, 4,
+                                  xs, ys, zs, ok)) {
+        return false;
+    }
+    for (int i = 0; i < 4; i++) {
+        if (!ok[i]) return false;
+    }
+
+    double xmin = xs[0], xmax = xs[0], ymin = ys[0], ymax = ys[0];
+    for (int i = 1; i < 4; i++) {
+        xmin = std::min(xmin, xs[i]); xmax = std::max(xmax, xs[i]);
+        ymin = std::min(ymin, ys[i]); ymax = std::max(ymax, ys[i]);
+    }
+
+    int sx = GDALGetRasterXSize(src_ds);
+    int sy = GDALGetRasterYSize(src_ds);
+
+    int x0 = (int)std::floor(xmin) - margin_px;
+    int y0 = (int)std::floor(ymin) - margin_px;
+    int x1 = (int)std::ceil(xmax)  + margin_px;
+    int y1 = (int)std::ceil(ymax)  + margin_px;
+
+    // If the inflated bbox is entirely off the source raster, the tile
+    // can only contain nodata (warp would fill with the dst nodata) — exact
+    // skip. We still report the clipped (empty) window so callers don't
+    // try to read it.
+    if (x1 <= 0 || y1 <= 0 || x0 >= sx || y0 >= sy) {
+        outside_source = true;
+        wx0 = wy0 = wx1 = wy1 = 0;
+        return true;
+    }
+
+    wx0 = std::max(0, x0);
+    wy0 = std::max(0, y0);
+    wx1 = std::min(sx, x1);
+    wy1 = std::min(sy, y1);
+    return wx1 > wx0 && wy1 > wy0;
+}
+
+// ─────────────────────────────────────────────
+// Helper: Free, IO-less geometric pre-check.
+// Returns true iff the dst tile back-projects entirely outside the source
+// raster's pixel extent — a guaranteed-empty tile.
+// ─────────────────────────────────────────────
+static bool IsTileOutsideSource(GDALDatasetH src_ds, void *transformer,
+                                 int dst_tile_size, int margin_px = 2) {
+    int wx0, wy0, wx1, wy1;
+    bool outside = false;
+    if (!BackProjectTileToSource(src_ds, transformer, dst_tile_size, margin_px,
+                                  wx0, wy0, wx1, wy1, outside)) {
+        return false;  // transformer failure — keep tile
+    }
+    return outside;
+}
+
+// ─────────────────────────────────────────────
+// Helper: Gated IO probe.
+// Reads the back-projected source window for each band's MASK (0 = nodata,
+// 255 = valid; GDAL synthesizes from nodata when no explicit mask band is
+// set) at sub-resolution (`probe` × `probe`) using AVERAGE resampling.
+//
+// Why mask + average instead of band + nearest:
+// Sub-sampling a sparse data band with nearest-neighbour can miss valid
+// pixels that fall between the sample grid points — false-positive empty.
+// Averaging the 0/255 mask across pooled cells preserves the "any valid
+// pixel exists" semantics: a pool with even one valid pixel produces
+// average > 0; only fully-nodata pools produce 0. Catches sparse
+// coverage that nearest sub-sampling would silently drop.
+//
+// Bands with `band_is_empty[i]` skip the read entirely (known fully-
+// nodata at bind time). Returns false on any transformer/IO failure or
+// on missing nodata definitions, so the caller falls back to the regular
+// warp + post-warp IsTileEmpty path.
+// ─────────────────────────────────────────────
+static bool IsSourceWindowEmpty(GDALDatasetH src_ds, void *transformer,
+                                 int dst_tile_size,
+                                 const std::vector<double> &band_nodatas,
+                                 const std::vector<bool> &band_has_nodata,
+                                 const std::vector<bool> &band_is_empty,
+                                 int probe = 32, int margin_px = 2) {
+    int band_count = GDALGetRasterCount(src_ds);
+    if (band_count == 0) return false;
+    if (static_cast<int>(band_has_nodata.size()) < band_count) return false;
+    for (int i = 0; i < band_count; i++) {
+        if (!band_has_nodata[i]) return false;
+    }
+
+    int wx0, wy0, wx1, wy1;
+    bool outside = false;
+    if (!BackProjectTileToSource(src_ds, transformer, dst_tile_size, margin_px,
+                                  wx0, wy0, wx1, wy1, outside)) {
+        return false;
+    }
+    if (outside) return true;
+
+    int wxs = wx1 - wx0;
+    int wys = wy1 - wy0;
+    if (wxs <= 0 || wys <= 0) return false;
+
+    GDALRasterIOExtraArg arg;
+    INIT_RASTERIO_EXTRA_ARG(arg);
+    arg.eResampleAlg = GRIORA_Average;
+
+    std::vector<uint8_t> mask_buf(static_cast<size_t>(probe) * probe);
+
+    for (int b = 1; b <= band_count; b++) {
+        if (b - 1 < (int)band_is_empty.size() && band_is_empty[b - 1]) continue;
+
+        GDALRasterBandH band = GDALGetRasterBand(src_ds, b);
+        GDALRasterBandH mask = GDALGetMaskBand(band);
+        if (!mask) return false;
+
+        std::fill(mask_buf.begin(), mask_buf.end(), 0);
+        CPLErr err = GDALRasterIOEx(mask, GF_Read, wx0, wy0, wxs, wys,
+                                     mask_buf.data(), probe, probe,
+                                     GDT_Byte, 0, 0, &arg);
+        if (err != CE_None) return false;
+
+        for (uint8_t v : mask_buf) {
+            // Any non-zero pool means at least one valid pixel exists.
+            if (v != 0) return false;
+        }
+    }
+    return true;
+}
+
+// ─────────────────────────────────────────────
 // Helper: Check if a tile is entirely nodata (empty)
 // ─────────────────────────────────────────────
 // A tile is empty only if EVERY band is fully nodata. Short-circuits on the
@@ -446,9 +629,14 @@ static void WarpIntoTile(ReadRasterLocalState &local, GDALDatasetH tile_ds,
 // value (per-band nodata is allowed by GDAL). If any band lacks a defined
 // nodata, or the read fails, returns false (keep the tile) — we cannot
 // prove emptiness and dropping the tile would silently lose valid data.
+//
+// `band_is_empty` lets callers cull bands that are known fully-nodata at
+// bind time (valid_percent == 0). Passing an empty vector disables the
+// cull and behaves as before.
 static bool IsTileEmpty(GDALDatasetH ds,
                          const std::vector<double> &band_nodatas,
-                         const std::vector<bool> &band_has_nodata) {
+                         const std::vector<bool> &band_has_nodata,
+                         const std::vector<bool> &band_is_empty = {}) {
     int band_count = GDALGetRasterCount(ds);
     if (band_count == 0) return false;
 
@@ -463,6 +651,8 @@ static bool IsTileEmpty(GDALDatasetH ds,
 
     std::vector<uint8_t> buf;
     for (int b = 1; b <= band_count; b++) {
+        if (b - 1 < (int)band_is_empty.size() && band_is_empty[b - 1]) continue;
+
         GDALRasterBandH band = GDALGetRasterBand(ds, b);
         GDALDataType dt = GDALGetRasterDataType(band);
         int dt_size = GDALGetDataTypeSizeBytes(dt);
@@ -477,20 +667,7 @@ static bool IsTileEmpty(GDALDatasetH ds,
 
         for (size_t i = 0; i < num_pixels; i++) {
             double val = 0;
-            switch (dt) {
-                case GDT_Byte:    val = static_cast<double>(buf[i]); break;
-                case GDT_Int8:    { int8_t v; memcpy(&v, buf.data() + i, 1); val = v; break; }
-                case GDT_Int16:   { int16_t v; memcpy(&v, buf.data() + i * 2, 2); val = v; break; }
-                case GDT_UInt16:  { uint16_t v; memcpy(&v, buf.data() + i * 2, 2); val = v; break; }
-                case GDT_Int32:   { int32_t v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
-                case GDT_UInt32:  { uint32_t v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
-                case GDT_Int64:   { int64_t v; memcpy(&v, buf.data() + i * 8, 8); val = static_cast<double>(v); break; }
-                case GDT_UInt64:  { uint64_t v; memcpy(&v, buf.data() + i * 8, 8); val = static_cast<double>(v); break; }
-                case GDT_Float32: { float v; memcpy(&v, buf.data() + i * 4, 4); val = v; break; }
-                case GDT_Float64: { memcpy(&val, buf.data() + i * 8, 8); break; }
-                default: return false;
-            }
-
+            if (!DecodePixel(dt, buf.data(), i, val)) return false;
             bool pixel_is_nodata = is_nan_nodata ? std::isnan(val) : (val == nodata);
             if (!pixel_is_nodata) return false;
         }
@@ -792,6 +969,13 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
             }
         } else if (kv.first == "approx") {
             bind_data->approx_stats = kv.second.GetValue<bool>();
+        } else if (kv.first == "sparsity_probe") {
+            auto v = StringUtil::Lower(kv.second.GetValue<string>());
+            if      (v == "auto") bind_data->sparsity_probe = SparsityProbe::Auto;
+            else if (v == "on")   bind_data->sparsity_probe = SparsityProbe::On;
+            else if (v == "off")  bind_data->sparsity_probe = SparsityProbe::Off;
+            else throw InvalidInputException(
+                "sparsity_probe must be 'auto', 'on', or 'off'");
         }
     }
 
@@ -900,6 +1084,35 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
             st.top_values    = std::move(v01.top_values);
         }
         bind_data->band_stats.push_back(st);
+    }
+
+    // Resolve the sparsity-probe gate. Auto enables the IO probe when at
+    // least one band has bind-time stats and max(valid_percent) is below
+    // the cutoff; otherwise the probe is off. On/Off honor the user's
+    // choice directly. band_is_empty is populated unconditionally so the
+    // per-band cull in IsTileEmpty can run regardless of probe state.
+    {
+        constexpr double SPARSITY_AUTO_VALID_PCT_CUTOFF = 95.0;
+        bind_data->band_is_empty.assign(bind_data->raster_band_count, false);
+        double max_valid_pct = -1.0;
+        for (int i = 0; i < bind_data->raster_band_count; i++) {
+            const auto &st = bind_data->band_stats[i];
+            if (!st.has_stats) continue;
+            if (st.valid_percent <= 0.0) bind_data->band_is_empty[i] = true;
+            max_valid_pct = std::max(max_valid_pct, st.valid_percent);
+        }
+        switch (bind_data->sparsity_probe) {
+            case SparsityProbe::On:
+                bind_data->sparsity_probe_active = true;
+                break;
+            case SparsityProbe::Off:
+                bind_data->sparsity_probe_active = false;
+                break;
+            case SparsityProbe::Auto:
+                bind_data->sparsity_probe_active =
+                    (max_valid_pct >= 0.0 && max_valid_pct < SPARSITY_AUTO_VALID_PCT_CUTOFF);
+                break;
+        }
     }
 
     // CF time dimension extraction (NetCDF)
@@ -1282,21 +1495,44 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             bind_data.raster_band_count, bind_data.gdal_dtype,
             state.nodata_value, state.has_nodata, tile_path);
 
-        WarpIntoTile(local, tile_ds, state.source_resampling,
-                     state.nodata_value, state.has_nodata);
+        // Pre-warp emptiness checks: build the transformer first so both
+        // the geometric pre-check and the IO probe can use it. The geometric
+        // check is free (no IO) and runs whenever sparsity_probe != Off.
+        // The IO probe is gated by sparsity_probe_active (resolved at bind
+        // time from sparsity_probe + valid_percent stats).
+        bool pre_warp_skip = false;
+        if (bind_data.sparsity_probe != SparsityProbe::Off) {
+            EnsureWarpTransformer(local, tile_ds, /*overview_level=*/-1);
+            pre_warp_skip = IsTileOutsideSource(local.src_ds, local.warp_transformer,
+                                                 bind_data.block_size);
+            if (!pre_warp_skip && bind_data.sparsity_probe_active) {
+                pre_warp_skip = IsSourceWindowEmpty(
+                    local.src_ds, local.warp_transformer,
+                    bind_data.block_size,
+                    bind_data.band_nodatas, bind_data.band_has_nodata,
+                    bind_data.band_is_empty);
+            }
+        }
 
-        bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas, bind_data.band_has_nodata);
+        if (!pre_warp_skip) {
+            WarpIntoTile(local, tile_ds, state.source_resampling,
+                         state.nodata_value, state.has_nodata);
 
-        if (!empty) {
-            auto tile_data = ReadAndCompressBands(
-                tile_ds, bind_data.compression, bind_data.compression_quality,
-                bind_data.band_layout, bind_data.statistics,
-                bind_data.raquet_dtype, state.has_nodata, state.nodata_value);
+            bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas,
+                                     bind_data.band_has_nodata,
+                                     bind_data.band_is_empty);
 
-            uint64_t block = quadbin::tile_to_cell(tile.x, tile.y, tile.z);
-            EmitTileRow(output, row_count, bind_data, block, tile_data);
-            state.total_blocks++;
-            row_count++;
+            if (!empty) {
+                auto tile_data = ReadAndCompressBands(
+                    tile_ds, bind_data.compression, bind_data.compression_quality,
+                    bind_data.band_layout, bind_data.statistics,
+                    bind_data.raquet_dtype, state.has_nodata, state.nodata_value);
+
+                uint64_t block = quadbin::tile_to_cell(tile.x, tile.y, tile.z);
+                EmitTileRow(output, row_count, bind_data, block, tile_data);
+                state.total_blocks++;
+                row_count++;
+            }
         }
 
         GDALClose(tile_ds);
@@ -1384,14 +1620,10 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                 bind_data.raster_band_count, bind_data.gdal_dtype,
                 state.nodata_value, state.has_nodata, ovr_path);
 
-            // Try COG overview fast path: read directly from a source overview
-            // level with a matching reduction factor instead of re-warping
-            // from the base resolution. Geometrically valid for any source
-            // CRS — the destination tile is in Web Mercator regardless of
-            // source, and the warper reprojects from the chosen overview just
-            // as it would from the base. The tolerance check on the reduction
-            // factor is what validates suitability.
-            bool used_cog = false;
+            // Decide the source overview level upfront so the pre-warp
+            // probe and the warp itself share one transformer. -1 means
+            // "warp from base resolution" (no COG fast path).
+            int chosen_overview = -1;
             if (bind_data.overview_count > 0) {
                 int zoom_diff = bind_data.max_zoom - frame.tile.z;
                 int reduction_factor = 1 << zoom_diff;
@@ -1403,41 +1635,64 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                         int ovr_xsize = GDALGetRasterBandXSize(ovr);
                         double ovr_reduction = static_cast<double>(src_xsize) / ovr_xsize;
                         if (std::abs(ovr_reduction - reduction_factor) / reduction_factor < 0.1) {
-                            WarpIntoTile(local, tile_ds, GRA_NearestNeighbour,
-                                         state.nodata_value, state.has_nodata, i);
-                            used_cog = true;
+                            chosen_overview = i;
                             break;
                         }
                     }
                 }
             }
 
-            if (!used_cog) {
-                // Fallback: warp from base resolution. Honour the user's
-                // resampling= named param (default GRA_NearestNeighbour) so
-                // Phase 2 fallback is consistent with Phase 1. Hardcoding
-                // GRA_Average here was wrong for categorical/palette bands —
-                // averaging neighbouring class IDs invents values that don't
-                // exist in the source (e.g. avg(10,20)=15 for a discrete
-                // class raster).
-                WarpIntoTile(local, tile_ds, state.source_resampling,
-                             state.nodata_value, state.has_nodata);
+            // Pre-warp emptiness checks (same logic as Phase 1, sharing the
+            // transformer at chosen_overview). The IO probe at sub-resolution
+            // implicitly uses the cheapest GDAL overview anyway.
+            bool pre_warp_skip = false;
+            if (bind_data.sparsity_probe != SparsityProbe::Off) {
+                EnsureWarpTransformer(local, tile_ds, chosen_overview);
+                pre_warp_skip = IsTileOutsideSource(local.src_ds, local.warp_transformer,
+                                                     bind_data.block_size);
+                if (!pre_warp_skip && bind_data.sparsity_probe_active) {
+                    pre_warp_skip = IsSourceWindowEmpty(
+                        local.src_ds, local.warp_transformer,
+                        bind_data.block_size,
+                        bind_data.band_nodatas, bind_data.band_has_nodata,
+                        bind_data.band_is_empty);
+                }
             }
 
-            bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas, bind_data.band_has_nodata);
-
-            if (!empty) {
-                auto tile_data = ReadAndCompressBands(
-                    tile_ds, bind_data.compression, bind_data.compression_quality,
-                    bind_data.band_layout, bind_data.statistics,
-                    bind_data.raquet_dtype, state.has_nodata, state.nodata_value);
-
-                uint64_t block = quadbin::tile_to_cell(frame.tile.x, frame.tile.y, frame.tile.z);
-                {
-                    std::lock_guard<std::mutex> lock(state.overview_results_mutex);
-                    state.overview_results.push_back({block, std::move(tile_data)});
+            if (!pre_warp_skip) {
+                if (chosen_overview >= 0) {
+                    // COG fast path: read directly from the matching source
+                    // overview. Geometrically valid for any source CRS —
+                    // the destination tile is in Web Mercator regardless,
+                    // and the warper reprojects from the chosen overview
+                    // just as it would from base.
+                    WarpIntoTile(local, tile_ds, GRA_NearestNeighbour,
+                                 state.nodata_value, state.has_nodata, chosen_overview);
+                } else {
+                    // Fallback: warp from base resolution. Honour the user's
+                    // resampling= named param (default GRA_NearestNeighbour)
+                    // so Phase 2 fallback is consistent with Phase 1.
+                    WarpIntoTile(local, tile_ds, state.source_resampling,
+                                 state.nodata_value, state.has_nodata);
                 }
-                state.total_blocks++;
+
+                bool empty = IsTileEmpty(tile_ds, bind_data.band_nodatas,
+                                         bind_data.band_has_nodata,
+                                         bind_data.band_is_empty);
+
+                if (!empty) {
+                    auto tile_data = ReadAndCompressBands(
+                        tile_ds, bind_data.compression, bind_data.compression_quality,
+                        bind_data.band_layout, bind_data.statistics,
+                        bind_data.raquet_dtype, state.has_nodata, state.nodata_value);
+
+                    uint64_t block = quadbin::tile_to_cell(frame.tile.x, frame.tile.y, frame.tile.z);
+                    {
+                        std::lock_guard<std::mutex> lock(state.overview_results_mutex);
+                        state.overview_results.push_back({block, std::move(tile_data)});
+                    }
+                    state.total_blocks++;
+                }
             }
 
             GDALClose(tile_ds);
@@ -1636,6 +1891,7 @@ void RegisterReadRaster(ExtensionLoader &loader) {
     func.named_parameters["zoom_strategy"] = LogicalType::VARCHAR;
     func.named_parameters["format"] = LogicalType::VARCHAR;
     func.named_parameters["approx"] = LogicalType::BOOLEAN;
+    func.named_parameters["sparsity_probe"] = LogicalType::VARCHAR;
     func.cardinality = ReadRasterCardinality;
 
     loader.RegisterFunction(func);

--- a/src/raster/read_raster.cpp
+++ b/src/raster/read_raster.cpp
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <cmath>
 #include <condition_variable>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -38,6 +39,20 @@
 #include <vector>
 
 namespace duckdb {
+
+// ─────────────────────────────────────────────
+// Debug-timing instrumentation: only emits stderr lines when the env
+// var RAQUET_DEBUG_TIMING is set (any non-empty value). Cached on first
+// read to avoid repeated getenv() calls. The atomic timestamp stores in
+// the global state run unconditionally — they're cheap and harmless.
+// ─────────────────────────────────────────────
+static bool DebugTimingEnabled() {
+    static const bool enabled = []() {
+        const char *v = std::getenv("RAQUET_DEBUG_TIMING");
+        return v != nullptr && v[0] != '\0';
+    }();
+    return enabled;
+}
 
 // ─────────────────────────────────────────────
 // GDAL type → raquet BandDataType string mapping
@@ -160,6 +175,14 @@ struct ReadRasterBindData : public TableFunctionData {
     bool sparsity_probe_active = false;     // resolved at bind time
     std::vector<bool> band_is_empty;        // valid_percent <= 0 ⇒ true
 
+    // Mask-buffer dimension for the IO probe (32×32 default). Smaller values
+    // (8, 16) read fewer mask cells per probe — faster, but with sparse
+    // rasters whose source overviews were built with -r nearest, smaller
+    // probes can produce false-positive empty (tile dropped despite
+    // having valid pixels). 32 is the empirically-validated sweet spot.
+    // Capped at block_size (no point probing finer than the destination).
+    int sparsity_probe_size = 32;
+
     // Band filter — 1-based source-band indices to emit, in output order.
     // Empty after parsing means "use all source bands"; the post-parse fill
     // populates 1..raster_band_count in that case so downstream code never
@@ -211,7 +234,41 @@ struct OverviewFrame {
 };
 
 // ─────────────────────────────────────────────
-// Global state — two-phase: parallel native zoom, then single-thread overviews
+// Execution state machine — three phases, transitions enforced via the
+// atomic flags below.
+//
+//   Phase 1 — Native-zoom tiles (parallel)
+//     Workers pull from `native_tiles` via `next_tile_idx` (mutex
+//     protected). Each tile: pre-warp checks → `WarpIntoTile` from
+//     source base resolution → compress → emit row to the output
+//     DataChunk directly. Last finisher (`phase1_finished` lands on
+//     `native_tiles.size()`) wakes the Phase 2 init winner.
+//
+//   Phase 2 — Overview tiles (parallel + single-shot init)
+//     One thread (the "init winner", elected via
+//     `phase2_init_claimed`) waits for Phase 1 stragglers, then
+//     publishes the overview frame queue. All workers then pull from
+//     `overview_frames` via `next_overview_idx`. Each tile uses the
+//     COG fast path when source overviews exist, falling back to base
+//     warp otherwise. Results are pushed into the `overview_results`
+//     staging vector under a brief mutex; the staging is by design —
+//     it lets emission span multiple Execute() calls so we don't
+//     silently lose overview tiles past STANDARD_VECTOR_SIZE.
+//     Last Phase 2 finisher publishes `phase2_staged`.
+//
+//   Phase 3 — Drain + metadata (cooperative)
+//     Any worker can drain `overview_results` into output DataChunks
+//     via `overview_drain_idx`. Once drained, exactly one thread
+//     (elected via `metadata_emitted` CAS) builds and emits the
+//     `block=0` metadata row. After that, `finished` is set and all
+//     subsequent Execute() calls return zero rows.
+//
+// All cross-phase synchronization runs through one mutex/condvar
+// pair (`wait_mutex` / `wait_cv`); waiters use predicates that read
+// the relevant atomic.
+//
+// Set RAQUET_DEBUG_TIMING=1 to emit `[raquet-phase] ...` markers on
+// stderr at each transition.
 // ─────────────────────────────────────────────
 struct ReadRasterGlobalState : public GlobalTableFunctionState {
     // Phase 1: Native-zoom tiles (parallel-safe, mutex-protected queue)
@@ -998,6 +1055,15 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
             else if (v == "off")  bind_data->sparsity_probe = SparsityProbe::Off;
             else throw InvalidInputException(
                 "sparsity_probe must be 'auto', 'on', or 'off'");
+        } else if (kv.first == "sparsity_probe_size") {
+            int n = kv.second.GetValue<int32_t>();
+            if (n < 4) {
+                throw InvalidInputException(
+                    "sparsity_probe_size must be >= 4 (got %d) — anything "
+                    "smaller has too few mask cells to be statistically "
+                    "meaningful", n);
+            }
+            bind_data->sparsity_probe_size = n;
         } else if (kv.first == "bands") {
             // 'all' (case-insensitive) or empty → defer to default fill below.
             // Otherwise: comma-separated list of 1-based source-band indices.
@@ -1062,6 +1128,14 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
     if (bind_data->raster_band_count == 0) {
         GDALClose(ds);
         throw InvalidInputException("Raster file has no bands: %s", bind_data->filename);
+    }
+
+    // Cap sparsity_probe_size at block_size — anything finer than the
+    // destination tile size is meaningless (the probe is checking whether
+    // a future destination tile would be empty; sub-tile resolution gives
+    // no extra signal).
+    if (bind_data->sparsity_probe_size > bind_data->block_size) {
+        bind_data->sparsity_probe_size = bind_data->block_size;
     }
 
     // Resolve `bands` filter: if the user didn't specify (or passed 'all'),
@@ -1602,10 +1676,12 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
                 std::chrono::steady_clock::now() - state.init_start).count();
             if (state.phase1_first_ns.compare_exchange_strong(expected, now_ns)) {
-                fprintf(stderr, "[raquet-phase] phase1_first @ %.3fs (native_tiles=%zu, threads=%d)\n",
-                        now_ns / 1e9, state.native_tiles.size(),
-                        static_cast<int>(state.MaxThreads()));
-                fflush(stderr);
+                if (DebugTimingEnabled()) {
+                    fprintf(stderr, "[raquet-phase] phase1_first @ %.3fs (native_tiles=%zu, threads=%d)\n",
+                            now_ns / 1e9, state.native_tiles.size(),
+                            static_cast<int>(state.MaxThreads()));
+                    fflush(stderr);
+                }
             }
         }
 
@@ -1636,7 +1712,8 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                     local.src_ds, local.warp_transformer,
                     bind_data.block_size,
                     bind_data.band_nodatas, bind_data.band_has_nodata,
-                    bind_data.band_is_empty);
+                    bind_data.band_is_empty,
+                    bind_data.sparsity_probe_size);
             }
         }
 
@@ -1718,16 +1795,18 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                         std::chrono::steady_clock::now() - state.init_start).count();
                     state.phase1_done_ns.store(now_ns, std::memory_order_release);
                     state.phase2_init_ns.store(now_ns, std::memory_order_release);
-                    int64_t p1_first = state.phase1_first_ns.load(std::memory_order_acquire);
-                    fprintf(stderr,
-                        "[raquet-phase] phase1_done @ %.3fs (phase1_wall=%.3fs, "
-                        "native_tiles=%zu, emitted=%d, overview_frames=%zu)\n",
-                        now_ns / 1e9,
-                        (now_ns - p1_first) / 1e9,
-                        state.native_tiles.size(),
-                        state.total_blocks.load(),
-                        state.overview_frames.size());
-                    fflush(stderr);
+                    if (DebugTimingEnabled()) {
+                        int64_t p1_first = state.phase1_first_ns.load(std::memory_order_acquire);
+                        fprintf(stderr,
+                            "[raquet-phase] phase1_done @ %.3fs (phase1_wall=%.3fs, "
+                            "native_tiles=%zu, emitted=%d, overview_frames=%zu)\n",
+                            now_ns / 1e9,
+                            (now_ns - p1_first) / 1e9,
+                            state.native_tiles.size(),
+                            state.total_blocks.load(),
+                            state.overview_frames.size());
+                        fflush(stderr);
+                    }
                 }
                 state.phase2_init_done.store(true, std::memory_order_release);
                 // Wake siblings waiting on phase2_init_done, plus any thread
@@ -1798,7 +1877,8 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                         local.src_ds, local.warp_transformer,
                         bind_data.block_size,
                         bind_data.band_nodatas, bind_data.band_has_nodata,
-                        bind_data.band_is_empty);
+                        bind_data.band_is_empty,
+                        bind_data.sparsity_probe_size);
                 }
             }
 
@@ -1851,16 +1931,18 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                     int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         std::chrono::steady_clock::now() - state.init_start).count();
                     state.phase2_staged_ns.store(now_ns, std::memory_order_release);
-                    int64_t p2_init = state.phase2_init_ns.load(std::memory_order_acquire);
-                    fprintf(stderr,
-                        "[raquet-phase] phase2_staged @ %.3fs (phase2_wall=%.3fs, "
-                        "overview_frames=%zu, staged=%zu, total_blocks=%d)\n",
-                        now_ns / 1e9,
-                        (now_ns - p2_init) / 1e9,
-                        total_frames,
-                        state.overview_results.size(),
-                        state.total_blocks.load());
-                    fflush(stderr);
+                    if (DebugTimingEnabled()) {
+                        int64_t p2_init = state.phase2_init_ns.load(std::memory_order_acquire);
+                        fprintf(stderr,
+                            "[raquet-phase] phase2_staged @ %.3fs (phase2_wall=%.3fs, "
+                            "overview_frames=%zu, staged=%zu, total_blocks=%d)\n",
+                            now_ns / 1e9,
+                            (now_ns - p2_init) / 1e9,
+                            total_frames,
+                            state.overview_results.size(),
+                            state.total_blocks.load());
+                        fflush(stderr);
+                    }
                 }
                 state.phase2_staged.store(true, std::memory_order_release);
                 { std::lock_guard<std::mutex> lk(state.wait_mutex); }
@@ -1921,14 +2003,16 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
                 std::chrono::steady_clock::now() - state.init_start).count();
             state.phase3_done_ns.store(now_ns, std::memory_order_release);
-            int64_t p2_staged = state.phase2_staged_ns.load(std::memory_order_acquire);
-            fprintf(stderr,
-                "[raquet-phase] phase3_metadata @ %.3fs (drain+meta_wall=%.3fs, "
-                "total_blocks=%d)\n",
-                now_ns / 1e9,
-                (now_ns - p2_staged) / 1e9,
-                state.total_blocks.load());
-            fflush(stderr);
+            if (DebugTimingEnabled()) {
+                int64_t p2_staged = state.phase2_staged_ns.load(std::memory_order_acquire);
+                fprintf(stderr,
+                    "[raquet-phase] phase3_metadata @ %.3fs (drain+meta_wall=%.3fs, "
+                    "total_blocks=%d)\n",
+                    now_ns / 1e9,
+                    (now_ns - p2_staged) / 1e9,
+                    state.total_blocks.load());
+                fflush(stderr);
+            }
         }
         // Build metadata
         raquet::RaquetMetadata meta;
@@ -2073,6 +2157,7 @@ void RegisterReadRaster(ExtensionLoader &loader) {
     func.named_parameters["format"] = LogicalType::VARCHAR;
     func.named_parameters["approx"] = LogicalType::BOOLEAN;
     func.named_parameters["sparsity_probe"] = LogicalType::VARCHAR;
+    func.named_parameters["sparsity_probe_size"] = LogicalType::INTEGER;
     func.named_parameters["bands"] = LogicalType::VARCHAR;
     func.cardinality = ReadRasterCardinality;
 

--- a/src/raster/read_raster.cpp
+++ b/src/raster/read_raster.cpp
@@ -643,21 +643,24 @@ static bool IsTileOutsideSource(GDALDatasetH src_ds, void *transformer,
 // average > 0; only fully-nodata pools produce 0. Catches sparse
 // coverage that nearest sub-sampling would silently drop.
 //
-// Bands with `band_is_empty[i]` skip the read entirely (known fully-
-// nodata at bind time). Returns false on any transformer/IO failure or
-// on missing nodata definitions, so the caller falls back to the regular
-// warp + post-warp IsTileEmpty path.
+// `band_*` vectors are indexed by output position (0-based dense, size =
+// selected_bands.size()); each entry corresponds to source band
+// `selected_bands[i]` (1-based). Bands with `band_is_empty[i]` skip the
+// read entirely (known fully-nodata at bind time). Returns false on any
+// transformer/IO failure or on missing nodata definitions, so the caller
+// falls back to the regular warp + post-warp IsTileEmpty path.
 // ─────────────────────────────────────────────
 static bool IsSourceWindowEmpty(GDALDatasetH src_ds, void *transformer,
                                  int dst_tile_size,
                                  const std::vector<double> &band_nodatas,
                                  const std::vector<bool> &band_has_nodata,
                                  const std::vector<bool> &band_is_empty,
+                                 const std::vector<int> &selected_bands,
                                  int probe = 32, int margin_px = 2) {
-    int band_count = GDALGetRasterCount(src_ds);
-    if (band_count == 0) return false;
-    if (static_cast<int>(band_has_nodata.size()) < band_count) return false;
-    for (int i = 0; i < band_count; i++) {
+    int n = static_cast<int>(selected_bands.size());
+    if (n == 0) return false;
+    if (static_cast<int>(band_has_nodata.size()) < n) return false;
+    for (int i = 0; i < n; i++) {
         if (!band_has_nodata[i]) return false;
     }
 
@@ -679,10 +682,10 @@ static bool IsSourceWindowEmpty(GDALDatasetH src_ds, void *transformer,
 
     std::vector<uint8_t> mask_buf(static_cast<size_t>(probe) * probe);
 
-    for (int b = 1; b <= band_count; b++) {
-        if (b - 1 < (int)band_is_empty.size() && band_is_empty[b - 1]) continue;
+    for (int i = 0; i < n; i++) {
+        if (i < (int)band_is_empty.size() && band_is_empty[i]) continue;
 
-        GDALRasterBandH band = GDALGetRasterBand(src_ds, b);
+        GDALRasterBandH band = GDALGetRasterBand(src_ds, selected_bands[i]);
         GDALRasterBandH mask = GDALGetMaskBand(band);
         if (!mask) return false;
 
@@ -1713,6 +1716,7 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                     bind_data.block_size,
                     bind_data.band_nodatas, bind_data.band_has_nodata,
                     bind_data.band_is_empty,
+                    bind_data.selected_bands,
                     bind_data.sparsity_probe_size);
             }
         }
@@ -1878,6 +1882,7 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                         bind_data.block_size,
                         bind_data.band_nodatas, bind_data.band_has_nodata,
                         bind_data.band_is_empty,
+                        bind_data.selected_bands,
                         bind_data.sparsity_probe_size);
                 }
             }

--- a/src/table_functions/merge_bands.cpp
+++ b/src/table_functions/merge_bands.cpp
@@ -388,11 +388,33 @@ static std::string MergeMetadata(const std::vector<std::string> &paths,
         b = b.substr(0, vs) + new_name + b.substr(ve);
     }
 
-    // Step 3: extract per-band nodata, build top-level nodata array.
+    // Step 3: build the top-level nodata array.
+    //
+    // Use each input's TOP-LEVEL `nodata` field (scalar number in
+    // single-band raquet output — produced by `nodata_to_json`). Don't
+    // use bands[i].nodata, which raquet's v0 format quotes as a string
+    // ("255") for raster_loader compatibility — that's the per-band
+    // shape, not the top-level shape, and putting quoted strings in
+    // the top-level array confuses readers that expect numbers.
     std::vector<std::string> per_band_nodatas;
-    for (const auto &b : band_entries) {
-        std::string nd = TryExtractRawValue(b, "nodata");
-        per_band_nodatas.push_back(nd.empty() ? "null" : nd);
+    for (const auto &j : jsons) {
+        std::string nd = TryExtractRawValue(j, "nodata");
+        if (nd.empty()) {
+            per_band_nodatas.push_back("null");
+        } else if (!nd.empty() && nd.front() == '[') {
+            // Input was already multi-band (unusual for the merge use
+            // case but supported): extract its first element.
+            size_t pos = SkipWS(nd, 1);
+            if (pos < nd.size() - 1 && nd[pos] != ']') {
+                auto [vs, ve] = ReadJSONValue(nd, pos, nd.size() - 1);
+                per_band_nodatas.push_back(nd.substr(vs, ve - vs));
+            } else {
+                per_band_nodatas.push_back("null");
+            }
+        } else {
+            // Scalar number form — use directly.
+            per_band_nodatas.push_back(nd);
+        }
     }
 
     // Step 4: rebuild the merged metadata. Take input 0's JSON, then:

--- a/src/table_functions/merge_bands.cpp
+++ b/src/table_functions/merge_bands.cpp
@@ -186,6 +186,20 @@ static std::string Unquote(const std::string &raw) {
     return out;
 }
 
+// Replace the value of a top-level JSON object field with `new_value`
+// (which must be a complete, well-formed JSON value: a quoted string,
+// number, array, or object). Returns the original JSON unchanged if the
+// field is absent.
+static std::string ReplaceTopLevelField(std::string json, const std::string &key,
+                                          const std::string &new_value) {
+    size_t colon = FindTopLevelKey(json, 0, json.size(), key);
+    if (colon == std::string::npos) {
+        return json;
+    }
+    auto [vs, ve] = ReadJSONValue(json, colon + 1, json.size());
+    return json.substr(0, vs) + new_value + json.substr(ve);
+}
+
 // ─────────────────────────────────────────────
 // Bind state
 // ─────────────────────────────────────────────
@@ -418,6 +432,38 @@ static std::string MergeMetadata(const std::vector<std::string> &paths,
 }
 
 // ─────────────────────────────────────────────
+// Count the number of distinct block IDs in the union of all inputs'
+// data rows (block != 0). This is what `num_blocks` should be in the
+// merged metadata — it can't be inferred from any single input.
+//
+// Uses UNION (not UNION ALL) so DuckDB dedups across inputs naturally.
+// ─────────────────────────────────────────────
+static int64_t CountMergedBlocks(ClientContext &context,
+                                  const std::vector<std::string> &paths) {
+    if (paths.empty()) return 0;
+
+    std::stringstream sql;
+    sql << "SELECT COUNT(*) FROM (";
+    for (size_t i = 0; i < paths.size(); i++) {
+        if (i > 0) sql << " UNION ";
+        sql << "SELECT block FROM read_parquet(" << SqlSingleQuote(paths[i])
+            << ") WHERE block != 0";
+    }
+    sql << ")";
+
+    Connection con(*context.db);
+    auto result = con.Query(sql.str());
+    if (result->HasError()) {
+        throw InvalidInputException(
+            "raquet_merge_bands: failed to count merged blocks: %s",
+            result->GetError());
+    }
+    auto chunk = result->Fetch();
+    if (!chunk || chunk->size() == 0) return 0;
+    return chunk->GetValue(0, 0).GetValue<int64_t>();
+}
+
+// ─────────────────────────────────────────────
 // Build the data-join SQL: FULL OUTER JOIN of N parquet inputs on `block`.
 // Each input contributes its band_1 column under output name band_(i+1).
 // ─────────────────────────────────────────────
@@ -485,6 +531,13 @@ static unique_ptr<FunctionData> RaquetMergeBandsBind(
 
     // Validate + compose merged metadata.
     bind_data->merged_metadata = MergeMetadata(bind_data->input_paths, jsons);
+
+    // Recompute num_blocks: distinct block IDs in the union of all inputs'
+    // data rows. The composed metadata starts with input 0's value, which
+    // is wrong for any merge of >1 inputs (it's just one band's count).
+    int64_t merged_blocks = CountMergedBlocks(context, bind_data->input_paths);
+    bind_data->merged_metadata = ReplaceTopLevelField(
+        bind_data->merged_metadata, "num_blocks", std::to_string(merged_blocks));
 
     // Build the data-join SQL string for InitGlobal to execute.
     bind_data->join_sql = BuildJoinSQL(bind_data->input_paths);

--- a/src/table_functions/merge_bands.cpp
+++ b/src/table_functions/merge_bands.cpp
@@ -1,4 +1,5 @@
 #include "merge_bands.hpp"
+#include "raquet_metadata.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -10,8 +11,6 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
 
-#include <algorithm>
-#include <cstddef>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -20,224 +19,7 @@
 
 namespace duckdb {
 
-// ─────────────────────────────────────────────
-// Minimal JSON helpers — extract scalar fields and substrings from
-// well-formed raquet metadata JSON. The metadata is produced by our own
-// serializer (RaquetMetadata::to_json / to_json_v0) so we don't need a
-// full RFC-8259 parser; just enough to find specific keys at known
-// positions in the structure.
-//
-// All helpers assume the JSON is syntactically valid; they throw
-// InvalidInputException on missing/malformed fields rather than
-// silently returning defaults.
-// ─────────────────────────────────────────────
-
-// Skip whitespace starting at pos.
-static size_t SkipWS(const std::string &s, size_t pos) {
-    while (pos < s.size() && (s[pos] == ' ' || s[pos] == '\t' || s[pos] == '\n' || s[pos] == '\r')) {
-        pos++;
-    }
-    return pos;
-}
-
-// Find the position of a top-level key inside a JSON object substring.
-// Returns the position of the colon following "key", or std::string::npos
-// if not found. Top level here means depth == 1 — the keys directly
-// inside the outermost `{ ... }`. Handles nested objects/arrays
-// correctly via brace counting (keys at deeper levels are skipped).
-static size_t FindTopLevelKey(const std::string &json, size_t start, size_t end, const std::string &key) {
-    int depth = 0;
-    bool in_string = false;
-    bool escape = false;
-    std::string needle = "\"" + key + "\"";
-
-    for (size_t i = start; i < end; i++) {
-        char c = json[i];
-        if (escape) { escape = false; continue; }
-        if (in_string) {
-            if (c == '\\') escape = true;
-            else if (c == '"') in_string = false;
-            continue;
-        }
-        if (c == '"') {
-            // Check if this opens our needle at top level (one inside
-            // the outermost {})
-            if (depth == 1 && i + needle.size() <= end &&
-                json.compare(i, needle.size(), needle) == 0) {
-                size_t after = SkipWS(json, i + needle.size());
-                if (after < end && json[after] == ':') {
-                    return after;
-                }
-            }
-            in_string = true;
-            continue;
-        }
-        if (c == '{' || c == '[') depth++;
-        else if (c == '}' || c == ']') depth--;
-    }
-    return std::string::npos;
-}
-
-// Read a JSON value (string, number, array, object, true/false/null)
-// starting at pos. Returns the (start, end) range of the value (end is
-// one past the last char). Throws on malformed input.
-static std::pair<size_t, size_t> ReadJSONValue(const std::string &json, size_t pos, size_t end) {
-    pos = SkipWS(json, pos);
-    if (pos >= end) {
-        throw InvalidInputException("raquet_merge_bands: unexpected end of metadata JSON");
-    }
-    size_t value_start = pos;
-    char c = json[pos];
-
-    if (c == '"') {
-        // string
-        pos++;
-        bool escape = false;
-        while (pos < end) {
-            if (escape) { escape = false; pos++; continue; }
-            if (json[pos] == '\\') { escape = true; pos++; continue; }
-            if (json[pos] == '"') { pos++; return {value_start, pos}; }
-            pos++;
-        }
-        throw InvalidInputException("raquet_merge_bands: unterminated string in metadata JSON");
-    }
-    if (c == '{' || c == '[') {
-        char open = c;
-        char close = (c == '{') ? '}' : ']';
-        int depth = 1;
-        pos++;
-        bool in_string = false;
-        bool escape = false;
-        while (pos < end && depth > 0) {
-            if (escape) { escape = false; pos++; continue; }
-            if (in_string) {
-                if (json[pos] == '\\') escape = true;
-                else if (json[pos] == '"') in_string = false;
-            } else {
-                if (json[pos] == '"') in_string = true;
-                else if (json[pos] == open) depth++;
-                else if (json[pos] == close) depth--;
-            }
-            pos++;
-        }
-        if (depth != 0) {
-            throw InvalidInputException("raquet_merge_bands: unbalanced brackets in metadata JSON");
-        }
-        return {value_start, pos};
-    }
-    // number / true / false / null — read until comma, closing bracket, or whitespace
-    while (pos < end) {
-        char ch = json[pos];
-        if (ch == ',' || ch == '}' || ch == ']' || ch == ' ' ||
-            ch == '\t' || ch == '\n' || ch == '\r') {
-            return {value_start, pos};
-        }
-        pos++;
-    }
-    return {value_start, pos};
-}
-
-// Extract the raw JSON substring of a top-level field.
-// Returns the value as it appears in the source (string with quotes,
-// number as digits, object/array with braces/brackets, etc.).
-// Throws on missing field.
-static std::string ExtractRawValue(const std::string &json, const std::string &key) {
-    size_t colon = FindTopLevelKey(json, 0, json.size(), key);
-    if (colon == std::string::npos) {
-        throw InvalidInputException("raquet_merge_bands: required field '%s' missing from metadata", key);
-    }
-    auto [start, end] = ReadJSONValue(json, colon + 1, json.size());
-    return json.substr(start, end - start);
-}
-
-// Try to extract a top-level field; returns empty string if absent.
-static std::string TryExtractRawValue(const std::string &json, const std::string &key) {
-    size_t colon = FindTopLevelKey(json, 0, json.size(), key);
-    if (colon == std::string::npos) {
-        return "";
-    }
-    auto [start, end] = ReadJSONValue(json, colon + 1, json.size());
-    return json.substr(start, end - start);
-}
-
-// Unquote a JSON string literal (assumes the value was extracted via
-// ReadJSONValue and includes the surrounding quotes).
-static std::string Unquote(const std::string &raw) {
-    if (raw.size() < 2 || raw[0] != '"' || raw[raw.size() - 1] != '"') {
-        return raw;  // not a string; return as-is
-    }
-    std::string out;
-    out.reserve(raw.size() - 2);
-    for (size_t i = 1; i < raw.size() - 1; i++) {
-        if (raw[i] == '\\' && i + 1 < raw.size() - 1) {
-            char nxt = raw[i + 1];
-            if (nxt == '"') out += '"';
-            else if (nxt == '\\') out += '\\';
-            else if (nxt == '/') out += '/';
-            else if (nxt == 'n') out += '\n';
-            else if (nxt == 't') out += '\t';
-            else if (nxt == 'r') out += '\r';
-            else { out += '\\'; out += nxt; }
-            i++;
-        } else {
-            out += raw[i];
-        }
-    }
-    return out;
-}
-
-// Replace the value of a top-level JSON object field with `new_value`
-// (which must be a complete, well-formed JSON value: a quoted string,
-// number, array, or object). Returns the original JSON unchanged if the
-// field is absent.
-static std::string ReplaceTopLevelField(std::string json, const std::string &key,
-                                          const std::string &new_value) {
-    size_t colon = FindTopLevelKey(json, 0, json.size(), key);
-    if (colon == std::string::npos) {
-        return json;
-    }
-    auto [vs, ve] = ReadJSONValue(json, colon + 1, json.size());
-    return json.substr(0, vs) + new_value + json.substr(ve);
-}
-
-// ─────────────────────────────────────────────
-// Bind state
-// ─────────────────────────────────────────────
-struct RaquetMergeBandsBindData : public TableFunctionData {
-    std::vector<std::string> input_paths;
-    std::string merged_metadata;          // composed at bind time
-    std::string join_sql;                 // SQL string executed in InitGlobal
-    std::vector<std::string> column_names;
-};
-
-struct RaquetMergeBandsGlobalState : public GlobalTableFunctionState {
-    std::unique_ptr<Connection> connection;
-    duckdb::unique_ptr<QueryResult> result;
-    duckdb::unique_ptr<DataChunk> current_chunk;
-    idx_t current_row = 0;
-    bool metadata_emitted = false;
-    bool finished = false;
-
-    idx_t MaxThreads() const override { return 1; }
-};
-
-// ─────────────────────────────────────────────
-// Validation
-// ─────────────────────────────────────────────
-static void EnsureFieldEqual(const std::string &field,
-                              const std::string &v0, const std::string &p0,
-                              const std::string &v1, const std::string &p1) {
-    if (v0 != v1) {
-        throw InvalidInputException(
-            "raquet_merge_bands: '%s' differs between '%s' (%s) and '%s' (%s) — "
-            "all inputs must share the same spatial frame",
-            field, p0, v0, p1, v1);
-    }
-}
-
-// ─────────────────────────────────────────────
-// SQL helpers
-// ─────────────────────────────────────────────
+// SQL single-quote escape — apostrophes inside the path are doubled.
 static std::string SqlSingleQuote(const std::string &s) {
     std::string out;
     out.reserve(s.size() + 2);
@@ -251,7 +33,8 @@ static std::string SqlSingleQuote(const std::string &s) {
 }
 
 // ─────────────────────────────────────────────
-// Read each input's metadata row via Connection
+// Read each input's metadata row via an internal Connection.
+// Returns the raw JSON strings; the caller parses them via parse_metadata.
 // ─────────────────────────────────────────────
 static std::vector<std::string> ReadMetadataJsons(ClientContext &context,
                                                    const std::vector<std::string> &paths) {
@@ -283,199 +66,98 @@ static std::vector<std::string> ReadMetadataJsons(ClientContext &context,
     return jsons;
 }
 
-// ─────────────────────────────────────────────
-// Compose merged metadata JSON from N inputs.
-// Validates compatibility, then splices the bands arrays.
-//
-// Strategy: keep the first input's full metadata as a base, then:
-//   1. Replace the top-level "bands" with a new array containing each
-//      input's bands[0] (with name renumbered to band_{i+1}).
-//   2. If "nodata" is present at top level as a scalar, replace with
-//      array [nd1..ndN].
-//
-// All other fields (version, compression, dimensions, bounds, etc.) are
-// kept from input 0 — they're validated to match across all inputs.
-// ─────────────────────────────────────────────
-static std::string MergeMetadata(const std::vector<std::string> &paths,
-                                  const std::vector<std::string> &jsons) {
-    if (jsons.empty()) {
-        throw InvalidInputException("raquet_merge_bands: at least one input required");
-    }
-
-    // Validate: extract spatial-frame fields from each, compare to input 0.
-    // Fields that must match exactly (as raw JSON values).
-    static const std::vector<std::string> required_match = {
-        "version", "compression", "block_width", "block_height",
-        "block_resolution", "bounds", "width", "height"
-    };
-    // min_zoom/minresolution and max_zoom/maxresolution have version-dependent
-    // names; check whichever is present.
-    static const std::vector<std::pair<std::string, std::string>> alt_keys = {
-        {"min_zoom", "minresolution"},
-        {"max_zoom", "maxresolution"},
-    };
-
-    auto first = jsons[0];
-    auto first_path = paths[0];
-
-    for (size_t i = 1; i < jsons.size(); i++) {
-        for (const auto &k : required_match) {
-            std::string a = TryExtractRawValue(first, k);
-            std::string b = TryExtractRawValue(jsons[i], k);
-            if (a.empty() && b.empty()) continue;  // neither has it — fine
-            EnsureFieldEqual(k, a, first_path, b, paths[i]);
-        }
-        for (const auto &kp : alt_keys) {
-            std::string a = TryExtractRawValue(first, kp.first);
-            if (a.empty()) a = TryExtractRawValue(first, kp.second);
-            std::string b = TryExtractRawValue(jsons[i], kp.first);
-            if (b.empty()) b = TryExtractRawValue(jsons[i], kp.second);
-            if (a.empty() && b.empty()) continue;
-            EnsureFieldEqual(kp.first, a, first_path, b, paths[i]);
-        }
-        // Compare band[0].type via a structural extract: the bands array's
-        // first element's "type" field. Approximate via substring search:
-        // both inputs are single-band so bands[0] is the only band.
-        std::string bands_a = TryExtractRawValue(first, "bands");
-        std::string bands_b = TryExtractRawValue(jsons[i], "bands");
-        if (!bands_a.empty() && !bands_b.empty()) {
-            // bands_X looks like [{...}] — look for "type":"..."
-            auto find_type = [](const std::string &arr) -> std::string {
-                size_t p = arr.find("\"type\"");
-                if (p == std::string::npos) return "";
-                p = arr.find(':', p);
-                if (p == std::string::npos) return "";
-                auto [vs, ve] = ReadJSONValue(arr, p + 1, arr.size());
-                return arr.substr(vs, ve - vs);
-            };
-            std::string ta = find_type(bands_a);
-            std::string tb = find_type(bands_b);
-            if (!ta.empty() && !tb.empty()) {
-                EnsureFieldEqual("bands[0].type", ta, first_path, tb, paths[i]);
-            }
-        }
-    }
-
-    // Compose merged JSON.
-    // Step 1: extract each input's bands[0] (the single-band entry).
-    std::vector<std::string> band_entries;
-    for (const auto &j : jsons) {
-        std::string bands = TryExtractRawValue(j, "bands");
-        if (bands.empty() || bands.front() != '[') {
-            throw InvalidInputException(
-                "raquet_merge_bands: input metadata missing or malformed 'bands' array");
-        }
-        // Extract first array element.
-        size_t pos = SkipWS(bands, 1);  // skip '['
-        if (pos >= bands.size() - 1 || bands[pos] == ']') {
-            throw InvalidInputException(
-                "raquet_merge_bands: input metadata has empty 'bands' array");
-        }
-        auto [vs, ve] = ReadJSONValue(bands, pos, bands.size() - 1);
-        band_entries.push_back(bands.substr(vs, ve - vs));
-    }
-
-    // Step 2: renumber each band's "name" AND "source_band" to its
-    // position in the merged raster (1..N). The output is a new
-    // self-contained multi-band raquet — the band at output position
-    // i+1 IS source band i+1 of THIS raster (regardless of which
-    // input file it came from). Leaving source_band as the original
-    // source-band index from the input parquet would confuse readers
-    // that use source_band to determine the default band to render
-    // (CARTO Builder defaults to source_band=1, which won't match the
-    // intended output column 1 if we don't renumber).
-    for (size_t i = 0; i < band_entries.size(); i++) {
-        std::string &b = band_entries[i];
-        size_t name_colon = FindTopLevelKey(b, 0, b.size(), "name");
-        if (name_colon == std::string::npos) {
-            throw InvalidInputException(
-                "raquet_merge_bands: band entry missing 'name' field");
-        }
-        auto [vs, ve] = ReadJSONValue(b, name_colon + 1, b.size());
-        std::string new_name = "\"band_" + std::to_string(i + 1) + "\"";
-        b = b.substr(0, vs) + new_name + b.substr(ve);
-
-        // Also replace source_band if present (the per-band source-band
-        // tracking from the bands= filter feature in PR #7).
-        size_t src_colon = FindTopLevelKey(b, 0, b.size(), "source_band");
-        if (src_colon != std::string::npos) {
-            auto [svs, sve] = ReadJSONValue(b, src_colon + 1, b.size());
-            b = b.substr(0, svs) + std::to_string(i + 1) + b.substr(sve);
-        }
-    }
-
-    // Step 3: build the top-level nodata array.
-    //
-    // Use each input's TOP-LEVEL `nodata` field (scalar number in
-    // single-band raquet output — produced by `nodata_to_json`). Don't
-    // use bands[i].nodata, which raquet's v0 format quotes as a string
-    // ("255") for raster_loader compatibility — that's the per-band
-    // shape, not the top-level shape, and putting quoted strings in
-    // the top-level array confuses readers that expect numbers.
-    std::vector<std::string> per_band_nodatas;
-    for (const auto &j : jsons) {
-        std::string nd = TryExtractRawValue(j, "nodata");
-        if (nd.empty()) {
-            per_band_nodatas.push_back("null");
-        } else if (!nd.empty() && nd.front() == '[') {
-            // Input was already multi-band (unusual for the merge use
-            // case but supported): extract its first element.
-            size_t pos = SkipWS(nd, 1);
-            if (pos < nd.size() - 1 && nd[pos] != ']') {
-                auto [vs, ve] = ReadJSONValue(nd, pos, nd.size() - 1);
-                per_band_nodatas.push_back(nd.substr(vs, ve - vs));
-            } else {
-                per_band_nodatas.push_back("null");
-            }
-        } else {
-            // Scalar number form — use directly.
-            per_band_nodatas.push_back(nd);
-        }
-    }
-
-    // Step 4: rebuild the merged metadata. Take input 0's JSON, then:
-    //   - replace top-level "bands" with the renumbered array
-    //   - replace top-level "nodata" (if scalar) with the array form
-    //
-    // We do this with substring replacement: find each field's
-    // (key+value) span and splice in the new value.
-    auto replace_field = [](std::string json, const std::string &key,
-                             const std::string &new_value) -> std::string {
-        size_t colon = FindTopLevelKey(json, 0, json.size(), key);
-        if (colon == std::string::npos) {
-            return json;  // field absent; caller should handle
-        }
-        auto [vs, ve] = ReadJSONValue(json, colon + 1, json.size());
-        return json.substr(0, vs) + new_value + json.substr(ve);
-    };
-
-    std::string new_bands = "[";
-    for (size_t i = 0; i < band_entries.size(); i++) {
-        if (i > 0) new_bands += ",";
-        new_bands += band_entries[i];
-    }
-    new_bands += "]";
-
-    std::string new_nodata = "[";
-    for (size_t i = 0; i < per_band_nodatas.size(); i++) {
-        if (i > 0) new_nodata += ",";
-        new_nodata += per_band_nodatas[i];
-    }
-    new_nodata += "]";
-
-    std::string merged = first;
-    merged = replace_field(merged, "bands", new_bands);
-    merged = replace_field(merged, "nodata", new_nodata);
-    return merged;
+// Detect output format from the input's raw JSON: v0.5.0+ outputs nest tile
+// geometry under "tiling": { ... }; v0.1.0 outputs it flat at top level.
+// Preserving the input format keeps the merged file legible by the same
+// readers that handled the inputs.
+static bool IsV05Format(const std::string &json) {
+    return json.find("\"tiling\"") != std::string::npos;
 }
 
 // ─────────────────────────────────────────────
-// Count the number of distinct block IDs in the union of all inputs'
-// data rows (block != 0). This is what `num_blocks` should be in the
-// merged metadata — it can't be inferred from any single input.
+// Validate input compatibility and build the merged RaquetMetadata.
+// Each input must be a single-band raquet (the only shape `bands='N'` in
+// read_raster produces). All inputs must share spatial frame and band[0]
+// type. Spatial-frame fields are compared as parsed struct values, not as
+// raw JSON strings — so two inputs whose JSON differs only in formatting
+// (whitespace, key order) still compare equal.
 //
-// Uses UNION (not UNION ALL) so DuckDB dedups across inputs naturally.
+// Returns the merged struct with num_blocks left as input 0's value;
+// caller must overwrite via CountMergedBlocks before serialising.
 // ─────────────────────────────────────────────
+static raquet::RaquetMetadata BuildMergedMetadata(
+        const std::vector<std::string> &paths,
+        const std::vector<raquet::RaquetMetadata> &metas) {
+
+    for (size_t i = 0; i < metas.size(); i++) {
+        if (metas[i].band_info.size() != 1) {
+            throw InvalidInputException(
+                "raquet_merge_bands: input '%s' has %d bands; only single-band "
+                "inputs are supported (use read_raster(..., bands='N') to produce them)",
+                paths[i], static_cast<int>(metas[i].band_info.size()));
+        }
+    }
+
+    auto fail_str = [&](const std::string &name, const std::string &a,
+                         const std::string &b, size_t i) {
+        throw InvalidInputException(
+            "raquet_merge_bands: '%s' differs between '%s' ('%s') and '%s' ('%s') — "
+            "all inputs must share the same spatial frame",
+            name, paths[0], a, paths[i], b);
+    };
+    auto fail_int = [&](const std::string &name, int a, int b, size_t i) {
+        throw InvalidInputException(
+            "raquet_merge_bands: '%s' differs between '%s' (%d) and '%s' (%d) — "
+            "all inputs must share the same spatial frame",
+            name, paths[0], a, paths[i], b);
+    };
+    auto fail_dbl = [&](const std::string &name, double a, double b, size_t i) {
+        throw InvalidInputException(
+            "raquet_merge_bands: '%s' differs between '%s' (%g) and '%s' (%g) — "
+            "all inputs must share the same spatial frame",
+            name, paths[0], a, paths[i], b);
+    };
+
+    const auto &m0 = metas[0];
+    for (size_t i = 1; i < metas.size(); i++) {
+        const auto &mi = metas[i];
+        if (m0.compression  != mi.compression)  fail_str("compression",  m0.compression,  mi.compression,  i);
+        if (m0.crs          != mi.crs)          fail_str("crs",          m0.crs,          mi.crs,          i);
+        if (m0.block_width  != mi.block_width)  fail_int("block_width",  m0.block_width,  mi.block_width,  i);
+        if (m0.block_height != mi.block_height) fail_int("block_height", m0.block_height, mi.block_height, i);
+        if (m0.min_zoom     != mi.min_zoom)     fail_int("min_zoom",     m0.min_zoom,     mi.min_zoom,     i);
+        if (m0.max_zoom     != mi.max_zoom)     fail_int("max_zoom",     m0.max_zoom,     mi.max_zoom,     i);
+        if (m0.width        != mi.width)        fail_int("width",        m0.width,        mi.width,        i);
+        if (m0.height       != mi.height)       fail_int("height",       m0.height,       mi.height,       i);
+        if (m0.bounds_minlon != mi.bounds_minlon) fail_dbl("bounds[0]", m0.bounds_minlon, mi.bounds_minlon, i);
+        if (m0.bounds_minlat != mi.bounds_minlat) fail_dbl("bounds[1]", m0.bounds_minlat, mi.bounds_minlat, i);
+        if (m0.bounds_maxlon != mi.bounds_maxlon) fail_dbl("bounds[2]", m0.bounds_maxlon, mi.bounds_maxlon, i);
+        if (m0.bounds_maxlat != mi.bounds_maxlat) fail_dbl("bounds[3]", m0.bounds_maxlat, mi.bounds_maxlat, i);
+        if (m0.band_info[0].type != mi.band_info[0].type) {
+            fail_str("bands[0].type", m0.band_info[0].type, mi.band_info[0].type, i);
+        }
+    }
+
+    // Compose: start from input 0 (carries all the validated common fields),
+    // replace the bands list with one entry per input. Each band entry is
+    // renumbered to its output position (name = "band_{i+1}", source_band =
+    // i+1) so downstream readers can map output columns back to source files.
+    raquet::RaquetMetadata merged = m0;
+    merged.band_info.clear();
+    merged.bands.clear();
+    for (size_t i = 0; i < metas.size(); i++) {
+        raquet::BandInfo bi = metas[i].band_info[0];
+        bi.name = "band_" + std::to_string(i + 1);
+        bi.source_band = static_cast<int>(i + 1);
+        merged.band_info.push_back(bi);
+        merged.bands.push_back({bi.name, bi.type});
+    }
+    return merged;
+}
+
+// Count distinct block IDs in the union of all inputs' data rows.
+// `num_blocks` in the merged metadata can't be inferred from any single
+// input — must be computed via a SQL union-dedup over all inputs.
 static int64_t CountMergedBlocks(ClientContext &context,
                                   const std::vector<std::string> &paths) {
     if (paths.empty()) return 0;
@@ -501,14 +183,11 @@ static int64_t CountMergedBlocks(ClientContext &context,
     return chunk->GetValue(0, 0).GetValue<int64_t>();
 }
 
-// ─────────────────────────────────────────────
-// Build the data-join SQL: FULL OUTER JOIN of N parquet inputs on `block`.
-// Each input contributes its band_1 column under output name band_(i+1).
-// ─────────────────────────────────────────────
+// Build the FULL OUTER JOIN of N input parquets on `block`. Each input
+// contributes its `band_1` column under output name `band_{i+1}`.
 static std::string BuildJoinSQL(const std::vector<std::string> &paths) {
     std::stringstream sql;
     sql << "SELECT ";
-    // COALESCE all inputs' block columns
     sql << "COALESCE(";
     for (size_t i = 0; i < paths.size(); i++) {
         if (i > 0) sql << ", ";
@@ -523,7 +202,6 @@ static std::string BuildJoinSQL(const std::vector<std::string> &paths) {
         sql << " FULL OUTER JOIN read_parquet(" << SqlSingleQuote(paths[i])
             << ") b" << (i + 1) << " USING (block)";
     }
-    // Filter out the metadata rows (block=0) from each input
     sql << " WHERE COALESCE(";
     for (size_t i = 0; i < paths.size(); i++) {
         if (i > 0) sql << ", ";
@@ -535,8 +213,31 @@ static std::string BuildJoinSQL(const std::vector<std::string> &paths) {
 }
 
 // ─────────────────────────────────────────────
-// Bind: parse list, read metadata from each input, validate, compose,
-// build SQL, set output schema.
+// Bind state
+// ─────────────────────────────────────────────
+struct RaquetMergeBandsBindData : public TableFunctionData {
+    std::vector<std::string> input_paths;
+    std::string merged_metadata;
+    std::string join_sql;
+};
+
+struct RaquetMergeBandsGlobalState : public GlobalTableFunctionState {
+    // Connection must outlive `result`; `result` must outlive
+    // `current_chunk`. Field-declaration order encodes this.
+    std::unique_ptr<Connection> connection;
+    duckdb::unique_ptr<QueryResult> result;
+    duckdb::unique_ptr<DataChunk> current_chunk;
+    idx_t current_row = 0;
+    bool metadata_emitted = false;
+    bool finished = false;
+
+    idx_t MaxThreads() const override { return 1; }
+};
+
+// ─────────────────────────────────────────────
+// Bind: read each input's metadata row, validate compatibility, compose
+// the merged metadata, recompute num_blocks, build the data-join SQL,
+// publish the output schema.
 // ─────────────────────────────────────────────
 static unique_ptr<FunctionData> RaquetMergeBandsBind(
         ClientContext &context, TableFunctionBindInput &input,
@@ -564,35 +265,43 @@ static unique_ptr<FunctionData> RaquetMergeBandsBind(
         bind_data->input_paths.push_back(v.GetValue<std::string>());
     }
 
-    // Read metadata rows from each input via Connection.
     auto jsons = ReadMetadataJsons(context, bind_data->input_paths);
 
-    // Validate + compose merged metadata.
-    bind_data->merged_metadata = MergeMetadata(bind_data->input_paths, jsons);
+    std::vector<raquet::RaquetMetadata> metas;
+    metas.reserve(jsons.size());
+    for (const auto &j : jsons) {
+        metas.push_back(raquet::parse_metadata(j));
+    }
 
-    // Recompute num_blocks: distinct block IDs in the union of all inputs'
-    // data rows. The composed metadata starts with input 0's value, which
-    // is wrong for any merge of >1 inputs (it's just one band's count).
-    int64_t merged_blocks = CountMergedBlocks(context, bind_data->input_paths);
-    bind_data->merged_metadata = ReplaceTopLevelField(
-        bind_data->merged_metadata, "num_blocks", std::to_string(merged_blocks));
+    auto merged = BuildMergedMetadata(bind_data->input_paths, metas);
+    merged.num_blocks = static_cast<int>(
+        CountMergedBlocks(context, bind_data->input_paths));
 
-    // Build the data-join SQL string for InitGlobal to execute.
+    // Preserve the input format. Mixed-format inputs would have failed
+    // validation already (different shapes parse to different structs);
+    // we sniff input 0's raw JSON here only to decide which serializer
+    // to call.
+    bind_data->merged_metadata = IsV05Format(jsons[0])
+        ? merged.to_json() : merged.to_json_v0();
+
     bind_data->join_sql = BuildJoinSQL(bind_data->input_paths);
 
-    // Output schema: block, metadata, band_1..band_N.
     names.push_back("block");      return_types.push_back(LogicalType::UBIGINT);
     names.push_back("metadata");   return_types.push_back(LogicalType::VARCHAR);
     for (size_t i = 0; i < bind_data->input_paths.size(); i++) {
         names.push_back("band_" + std::to_string(i + 1));
         return_types.push_back(LogicalType::BLOB);
     }
-    bind_data->column_names = names;
     return std::move(bind_data);
 }
 
 // ─────────────────────────────────────────────
-// InitGlobal: open a Connection, run the join SQL, store streaming result.
+// InitGlobal: open an internal Connection and submit the join SQL.
+// `Connection::Query` returns a MaterializedQueryResult — the entire
+// joined result-set is buffered in memory before Execute pulls chunks.
+// This is acceptable for the documented workflow (the per-band → merge
+// pattern exists to dodge the parquet writer's row-group buffering, not
+// the join's working set).
 // ─────────────────────────────────────────────
 static unique_ptr<GlobalTableFunctionState> RaquetMergeBandsInitGlobal(
         ClientContext &context, TableFunctionInitInput &input) {
@@ -610,8 +319,8 @@ static unique_ptr<GlobalTableFunctionState> RaquetMergeBandsInitGlobal(
 }
 
 // ─────────────────────────────────────────────
-// Execute: emit metadata row first, then stream chunks from the join
-// QueryResult into the output DataChunk.
+// Execute: emit the metadata row first (block=0, metadata=merged JSON,
+// band_* = NULL), then drain the join result chunk by chunk.
 // ─────────────────────────────────────────────
 static void RaquetMergeBandsExecute(ClientContext &context, TableFunctionInput &input,
                                      DataChunk &output) {
@@ -627,7 +336,6 @@ static void RaquetMergeBandsExecute(ClientContext &context, TableFunctionInput &
     idx_t max_rows = STANDARD_VECTOR_SIZE;
     idx_t band_count = bind.input_paths.size();
 
-    // Phase 1: emit metadata row exactly once
     if (!state.metadata_emitted) {
         FlatVector::GetData<uint64_t>(output.data[0])[out_row] = 0;
         FlatVector::GetData<string_t>(output.data[1])[out_row] =
@@ -639,7 +347,6 @@ static void RaquetMergeBandsExecute(ClientContext &context, TableFunctionInput &
         state.metadata_emitted = true;
     }
 
-    // Phase 2: stream from the join QueryResult
     while (out_row < max_rows) {
         if (!state.current_chunk || state.current_row >= state.current_chunk->size()) {
             state.current_chunk = state.result->Fetch();
@@ -649,11 +356,7 @@ static void RaquetMergeBandsExecute(ClientContext &context, TableFunctionInput &
                 break;
             }
         }
-        // Copy one row from current_chunk into output
         for (idx_t col = 0; col < band_count + 2; col++) {
-            // Use Vector::SetValue/GetValue for safety; performance is
-            // acceptable since each row is small (one UBIGINT + one
-            // VARCHAR + N BLOBs, all already in memory).
             Value v = state.current_chunk->GetValue(col, state.current_row);
             output.SetValue(col, out_row, v);
         }
@@ -664,13 +367,12 @@ static void RaquetMergeBandsExecute(ClientContext &context, TableFunctionInput &
     output.SetCardinality(out_row);
 }
 
-// ─────────────────────────────────────────────
-// Cardinality estimate
-// ─────────────────────────────────────────────
+// Rough cardinality estimate (planner hint only). Uses input 0's row
+// count; the FULL OUTER JOIN can return up to sum(rows[i]) when inputs
+// share few blocks, but most merges are produced from rasters with the
+// same spatial frame so input 0 is a reasonable lower bound.
 static unique_ptr<NodeStatistics> RaquetMergeBandsCardinality(
         ClientContext &context, const FunctionData *bind_data_p) {
-    // We don't know the joined row count without scanning. Provide a
-    // rough estimate based on the first input's row count.
     auto &bind = bind_data_p->Cast<RaquetMergeBandsBindData>();
     if (bind.input_paths.empty()) {
         return make_uniq<NodeStatistics>();
@@ -679,7 +381,7 @@ static unique_ptr<NodeStatistics> RaquetMergeBandsCardinality(
     auto q = "SELECT COUNT(*) FROM read_parquet(" +
              SqlSingleQuote(bind.input_paths[0]) + ") WHERE block != 0";
     auto result = con.Query(q);
-    if (result->HasError() || !result) {
+    if (!result || result->HasError()) {
         return make_uniq<NodeStatistics>();
     }
     auto chunk = result->Fetch();
@@ -690,9 +392,6 @@ static unique_ptr<NodeStatistics> RaquetMergeBandsCardinality(
     return make_uniq<NodeStatistics>(static_cast<idx_t>(n + 1));
 }
 
-// ─────────────────────────────────────────────
-// Registration
-// ─────────────────────────────────────────────
 void RegisterMergeBandsFunction(ExtensionLoader &loader) {
     TableFunction merge_fn(
         "raquet_merge_bands",

--- a/src/table_functions/merge_bands.cpp
+++ b/src/table_functions/merge_bands.cpp
@@ -375,7 +375,15 @@ static std::string MergeMetadata(const std::vector<std::string> &paths,
         band_entries.push_back(bands.substr(vs, ve - vs));
     }
 
-    // Step 2: renumber each band's "name" field.
+    // Step 2: renumber each band's "name" AND "source_band" to its
+    // position in the merged raster (1..N). The output is a new
+    // self-contained multi-band raquet — the band at output position
+    // i+1 IS source band i+1 of THIS raster (regardless of which
+    // input file it came from). Leaving source_band as the original
+    // source-band index from the input parquet would confuse readers
+    // that use source_band to determine the default band to render
+    // (CARTO Builder defaults to source_band=1, which won't match the
+    // intended output column 1 if we don't renumber).
     for (size_t i = 0; i < band_entries.size(); i++) {
         std::string &b = band_entries[i];
         size_t name_colon = FindTopLevelKey(b, 0, b.size(), "name");
@@ -386,6 +394,14 @@ static std::string MergeMetadata(const std::vector<std::string> &paths,
         auto [vs, ve] = ReadJSONValue(b, name_colon + 1, b.size());
         std::string new_name = "\"band_" + std::to_string(i + 1) + "\"";
         b = b.substr(0, vs) + new_name + b.substr(ve);
+
+        // Also replace source_band if present (the per-band source-band
+        // tracking from the bands= filter feature in PR #7).
+        size_t src_colon = FindTopLevelKey(b, 0, b.size(), "source_band");
+        if (src_colon != std::string::npos) {
+            auto [svs, sve] = ReadJSONValue(b, src_colon + 1, b.size());
+            b = b.substr(0, svs) + std::to_string(i + 1) + b.substr(sve);
+        }
     }
 
     // Step 3: build the top-level nodata array.

--- a/src/table_functions/merge_bands.cpp
+++ b/src/table_functions/merge_bands.cpp
@@ -1,0 +1,616 @@
+#include "merge_bands.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/query_result.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace duckdb {
+
+// ─────────────────────────────────────────────
+// Minimal JSON helpers — extract scalar fields and substrings from
+// well-formed raquet metadata JSON. The metadata is produced by our own
+// serializer (RaquetMetadata::to_json / to_json_v0) so we don't need a
+// full RFC-8259 parser; just enough to find specific keys at known
+// positions in the structure.
+//
+// All helpers assume the JSON is syntactically valid; they throw
+// InvalidInputException on missing/malformed fields rather than
+// silently returning defaults.
+// ─────────────────────────────────────────────
+
+// Skip whitespace starting at pos.
+static size_t SkipWS(const std::string &s, size_t pos) {
+    while (pos < s.size() && (s[pos] == ' ' || s[pos] == '\t' || s[pos] == '\n' || s[pos] == '\r')) {
+        pos++;
+    }
+    return pos;
+}
+
+// Find the position of a top-level key inside a JSON object substring.
+// Returns the position of the colon following "key", or std::string::npos
+// if not found. Top level here means depth == 1 — the keys directly
+// inside the outermost `{ ... }`. Handles nested objects/arrays
+// correctly via brace counting (keys at deeper levels are skipped).
+static size_t FindTopLevelKey(const std::string &json, size_t start, size_t end, const std::string &key) {
+    int depth = 0;
+    bool in_string = false;
+    bool escape = false;
+    std::string needle = "\"" + key + "\"";
+
+    for (size_t i = start; i < end; i++) {
+        char c = json[i];
+        if (escape) { escape = false; continue; }
+        if (in_string) {
+            if (c == '\\') escape = true;
+            else if (c == '"') in_string = false;
+            continue;
+        }
+        if (c == '"') {
+            // Check if this opens our needle at top level (one inside
+            // the outermost {})
+            if (depth == 1 && i + needle.size() <= end &&
+                json.compare(i, needle.size(), needle) == 0) {
+                size_t after = SkipWS(json, i + needle.size());
+                if (after < end && json[after] == ':') {
+                    return after;
+                }
+            }
+            in_string = true;
+            continue;
+        }
+        if (c == '{' || c == '[') depth++;
+        else if (c == '}' || c == ']') depth--;
+    }
+    return std::string::npos;
+}
+
+// Read a JSON value (string, number, array, object, true/false/null)
+// starting at pos. Returns the (start, end) range of the value (end is
+// one past the last char). Throws on malformed input.
+static std::pair<size_t, size_t> ReadJSONValue(const std::string &json, size_t pos, size_t end) {
+    pos = SkipWS(json, pos);
+    if (pos >= end) {
+        throw InvalidInputException("raquet_merge_bands: unexpected end of metadata JSON");
+    }
+    size_t value_start = pos;
+    char c = json[pos];
+
+    if (c == '"') {
+        // string
+        pos++;
+        bool escape = false;
+        while (pos < end) {
+            if (escape) { escape = false; pos++; continue; }
+            if (json[pos] == '\\') { escape = true; pos++; continue; }
+            if (json[pos] == '"') { pos++; return {value_start, pos}; }
+            pos++;
+        }
+        throw InvalidInputException("raquet_merge_bands: unterminated string in metadata JSON");
+    }
+    if (c == '{' || c == '[') {
+        char open = c;
+        char close = (c == '{') ? '}' : ']';
+        int depth = 1;
+        pos++;
+        bool in_string = false;
+        bool escape = false;
+        while (pos < end && depth > 0) {
+            if (escape) { escape = false; pos++; continue; }
+            if (in_string) {
+                if (json[pos] == '\\') escape = true;
+                else if (json[pos] == '"') in_string = false;
+            } else {
+                if (json[pos] == '"') in_string = true;
+                else if (json[pos] == open) depth++;
+                else if (json[pos] == close) depth--;
+            }
+            pos++;
+        }
+        if (depth != 0) {
+            throw InvalidInputException("raquet_merge_bands: unbalanced brackets in metadata JSON");
+        }
+        return {value_start, pos};
+    }
+    // number / true / false / null — read until comma, closing bracket, or whitespace
+    while (pos < end) {
+        char ch = json[pos];
+        if (ch == ',' || ch == '}' || ch == ']' || ch == ' ' ||
+            ch == '\t' || ch == '\n' || ch == '\r') {
+            return {value_start, pos};
+        }
+        pos++;
+    }
+    return {value_start, pos};
+}
+
+// Extract the raw JSON substring of a top-level field.
+// Returns the value as it appears in the source (string with quotes,
+// number as digits, object/array with braces/brackets, etc.).
+// Throws on missing field.
+static std::string ExtractRawValue(const std::string &json, const std::string &key) {
+    size_t colon = FindTopLevelKey(json, 0, json.size(), key);
+    if (colon == std::string::npos) {
+        throw InvalidInputException("raquet_merge_bands: required field '%s' missing from metadata", key);
+    }
+    auto [start, end] = ReadJSONValue(json, colon + 1, json.size());
+    return json.substr(start, end - start);
+}
+
+// Try to extract a top-level field; returns empty string if absent.
+static std::string TryExtractRawValue(const std::string &json, const std::string &key) {
+    size_t colon = FindTopLevelKey(json, 0, json.size(), key);
+    if (colon == std::string::npos) {
+        return "";
+    }
+    auto [start, end] = ReadJSONValue(json, colon + 1, json.size());
+    return json.substr(start, end - start);
+}
+
+// Unquote a JSON string literal (assumes the value was extracted via
+// ReadJSONValue and includes the surrounding quotes).
+static std::string Unquote(const std::string &raw) {
+    if (raw.size() < 2 || raw[0] != '"' || raw[raw.size() - 1] != '"') {
+        return raw;  // not a string; return as-is
+    }
+    std::string out;
+    out.reserve(raw.size() - 2);
+    for (size_t i = 1; i < raw.size() - 1; i++) {
+        if (raw[i] == '\\' && i + 1 < raw.size() - 1) {
+            char nxt = raw[i + 1];
+            if (nxt == '"') out += '"';
+            else if (nxt == '\\') out += '\\';
+            else if (nxt == '/') out += '/';
+            else if (nxt == 'n') out += '\n';
+            else if (nxt == 't') out += '\t';
+            else if (nxt == 'r') out += '\r';
+            else { out += '\\'; out += nxt; }
+            i++;
+        } else {
+            out += raw[i];
+        }
+    }
+    return out;
+}
+
+// ─────────────────────────────────────────────
+// Bind state
+// ─────────────────────────────────────────────
+struct RaquetMergeBandsBindData : public TableFunctionData {
+    std::vector<std::string> input_paths;
+    std::string merged_metadata;          // composed at bind time
+    std::string join_sql;                 // SQL string executed in InitGlobal
+    std::vector<std::string> column_names;
+};
+
+struct RaquetMergeBandsGlobalState : public GlobalTableFunctionState {
+    std::unique_ptr<Connection> connection;
+    duckdb::unique_ptr<QueryResult> result;
+    duckdb::unique_ptr<DataChunk> current_chunk;
+    idx_t current_row = 0;
+    bool metadata_emitted = false;
+    bool finished = false;
+
+    idx_t MaxThreads() const override { return 1; }
+};
+
+// ─────────────────────────────────────────────
+// Validation
+// ─────────────────────────────────────────────
+static void EnsureFieldEqual(const std::string &field,
+                              const std::string &v0, const std::string &p0,
+                              const std::string &v1, const std::string &p1) {
+    if (v0 != v1) {
+        throw InvalidInputException(
+            "raquet_merge_bands: '%s' differs between '%s' (%s) and '%s' (%s) — "
+            "all inputs must share the same spatial frame",
+            field, p0, v0, p1, v1);
+    }
+}
+
+// ─────────────────────────────────────────────
+// SQL helpers
+// ─────────────────────────────────────────────
+static std::string SqlSingleQuote(const std::string &s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    out += '\'';
+    for (char c : s) {
+        if (c == '\'') out += "''";
+        else out += c;
+    }
+    out += '\'';
+    return out;
+}
+
+// ─────────────────────────────────────────────
+// Read each input's metadata row via Connection
+// ─────────────────────────────────────────────
+static std::vector<std::string> ReadMetadataJsons(ClientContext &context,
+                                                   const std::vector<std::string> &paths) {
+    std::vector<std::string> jsons;
+    jsons.reserve(paths.size());
+
+    Connection con(*context.db);
+    for (const auto &p : paths) {
+        std::string q = "SELECT metadata FROM read_parquet(" + SqlSingleQuote(p) +
+                        ") WHERE block = 0";
+        auto result = con.Query(q);
+        if (result->HasError()) {
+            throw InvalidInputException(
+                "raquet_merge_bands: failed to read metadata from '%s': %s",
+                p, result->GetError());
+        }
+        auto chunk = result->Fetch();
+        if (!chunk || chunk->size() == 0) {
+            throw InvalidInputException(
+                "raquet_merge_bands: '%s' has no metadata row (block=0)", p);
+        }
+        Value v = chunk->GetValue(0, 0);
+        if (v.IsNull()) {
+            throw InvalidInputException(
+                "raquet_merge_bands: '%s' has NULL metadata at block=0", p);
+        }
+        jsons.push_back(v.GetValue<std::string>());
+    }
+    return jsons;
+}
+
+// ─────────────────────────────────────────────
+// Compose merged metadata JSON from N inputs.
+// Validates compatibility, then splices the bands arrays.
+//
+// Strategy: keep the first input's full metadata as a base, then:
+//   1. Replace the top-level "bands" with a new array containing each
+//      input's bands[0] (with name renumbered to band_{i+1}).
+//   2. If "nodata" is present at top level as a scalar, replace with
+//      array [nd1..ndN].
+//
+// All other fields (version, compression, dimensions, bounds, etc.) are
+// kept from input 0 — they're validated to match across all inputs.
+// ─────────────────────────────────────────────
+static std::string MergeMetadata(const std::vector<std::string> &paths,
+                                  const std::vector<std::string> &jsons) {
+    if (jsons.empty()) {
+        throw InvalidInputException("raquet_merge_bands: at least one input required");
+    }
+
+    // Validate: extract spatial-frame fields from each, compare to input 0.
+    // Fields that must match exactly (as raw JSON values).
+    static const std::vector<std::string> required_match = {
+        "version", "compression", "block_width", "block_height",
+        "block_resolution", "bounds", "width", "height"
+    };
+    // min_zoom/minresolution and max_zoom/maxresolution have version-dependent
+    // names; check whichever is present.
+    static const std::vector<std::pair<std::string, std::string>> alt_keys = {
+        {"min_zoom", "minresolution"},
+        {"max_zoom", "maxresolution"},
+    };
+
+    auto first = jsons[0];
+    auto first_path = paths[0];
+
+    for (size_t i = 1; i < jsons.size(); i++) {
+        for (const auto &k : required_match) {
+            std::string a = TryExtractRawValue(first, k);
+            std::string b = TryExtractRawValue(jsons[i], k);
+            if (a.empty() && b.empty()) continue;  // neither has it — fine
+            EnsureFieldEqual(k, a, first_path, b, paths[i]);
+        }
+        for (const auto &kp : alt_keys) {
+            std::string a = TryExtractRawValue(first, kp.first);
+            if (a.empty()) a = TryExtractRawValue(first, kp.second);
+            std::string b = TryExtractRawValue(jsons[i], kp.first);
+            if (b.empty()) b = TryExtractRawValue(jsons[i], kp.second);
+            if (a.empty() && b.empty()) continue;
+            EnsureFieldEqual(kp.first, a, first_path, b, paths[i]);
+        }
+        // Compare band[0].type via a structural extract: the bands array's
+        // first element's "type" field. Approximate via substring search:
+        // both inputs are single-band so bands[0] is the only band.
+        std::string bands_a = TryExtractRawValue(first, "bands");
+        std::string bands_b = TryExtractRawValue(jsons[i], "bands");
+        if (!bands_a.empty() && !bands_b.empty()) {
+            // bands_X looks like [{...}] — look for "type":"..."
+            auto find_type = [](const std::string &arr) -> std::string {
+                size_t p = arr.find("\"type\"");
+                if (p == std::string::npos) return "";
+                p = arr.find(':', p);
+                if (p == std::string::npos) return "";
+                auto [vs, ve] = ReadJSONValue(arr, p + 1, arr.size());
+                return arr.substr(vs, ve - vs);
+            };
+            std::string ta = find_type(bands_a);
+            std::string tb = find_type(bands_b);
+            if (!ta.empty() && !tb.empty()) {
+                EnsureFieldEqual("bands[0].type", ta, first_path, tb, paths[i]);
+            }
+        }
+    }
+
+    // Compose merged JSON.
+    // Step 1: extract each input's bands[0] (the single-band entry).
+    std::vector<std::string> band_entries;
+    for (const auto &j : jsons) {
+        std::string bands = TryExtractRawValue(j, "bands");
+        if (bands.empty() || bands.front() != '[') {
+            throw InvalidInputException(
+                "raquet_merge_bands: input metadata missing or malformed 'bands' array");
+        }
+        // Extract first array element.
+        size_t pos = SkipWS(bands, 1);  // skip '['
+        if (pos >= bands.size() - 1 || bands[pos] == ']') {
+            throw InvalidInputException(
+                "raquet_merge_bands: input metadata has empty 'bands' array");
+        }
+        auto [vs, ve] = ReadJSONValue(bands, pos, bands.size() - 1);
+        band_entries.push_back(bands.substr(vs, ve - vs));
+    }
+
+    // Step 2: renumber each band's "name" field.
+    for (size_t i = 0; i < band_entries.size(); i++) {
+        std::string &b = band_entries[i];
+        size_t name_colon = FindTopLevelKey(b, 0, b.size(), "name");
+        if (name_colon == std::string::npos) {
+            throw InvalidInputException(
+                "raquet_merge_bands: band entry missing 'name' field");
+        }
+        auto [vs, ve] = ReadJSONValue(b, name_colon + 1, b.size());
+        std::string new_name = "\"band_" + std::to_string(i + 1) + "\"";
+        b = b.substr(0, vs) + new_name + b.substr(ve);
+    }
+
+    // Step 3: extract per-band nodata, build top-level nodata array.
+    std::vector<std::string> per_band_nodatas;
+    for (const auto &b : band_entries) {
+        std::string nd = TryExtractRawValue(b, "nodata");
+        per_band_nodatas.push_back(nd.empty() ? "null" : nd);
+    }
+
+    // Step 4: rebuild the merged metadata. Take input 0's JSON, then:
+    //   - replace top-level "bands" with the renumbered array
+    //   - replace top-level "nodata" (if scalar) with the array form
+    //
+    // We do this with substring replacement: find each field's
+    // (key+value) span and splice in the new value.
+    auto replace_field = [](std::string json, const std::string &key,
+                             const std::string &new_value) -> std::string {
+        size_t colon = FindTopLevelKey(json, 0, json.size(), key);
+        if (colon == std::string::npos) {
+            return json;  // field absent; caller should handle
+        }
+        auto [vs, ve] = ReadJSONValue(json, colon + 1, json.size());
+        return json.substr(0, vs) + new_value + json.substr(ve);
+    };
+
+    std::string new_bands = "[";
+    for (size_t i = 0; i < band_entries.size(); i++) {
+        if (i > 0) new_bands += ",";
+        new_bands += band_entries[i];
+    }
+    new_bands += "]";
+
+    std::string new_nodata = "[";
+    for (size_t i = 0; i < per_band_nodatas.size(); i++) {
+        if (i > 0) new_nodata += ",";
+        new_nodata += per_band_nodatas[i];
+    }
+    new_nodata += "]";
+
+    std::string merged = first;
+    merged = replace_field(merged, "bands", new_bands);
+    merged = replace_field(merged, "nodata", new_nodata);
+    return merged;
+}
+
+// ─────────────────────────────────────────────
+// Build the data-join SQL: FULL OUTER JOIN of N parquet inputs on `block`.
+// Each input contributes its band_1 column under output name band_(i+1).
+// ─────────────────────────────────────────────
+static std::string BuildJoinSQL(const std::vector<std::string> &paths) {
+    std::stringstream sql;
+    sql << "SELECT ";
+    // COALESCE all inputs' block columns
+    sql << "COALESCE(";
+    for (size_t i = 0; i < paths.size(); i++) {
+        if (i > 0) sql << ", ";
+        sql << "b" << (i + 1) << ".block";
+    }
+    sql << ") AS block, NULL::VARCHAR AS metadata";
+    for (size_t i = 0; i < paths.size(); i++) {
+        sql << ", b" << (i + 1) << ".band_1 AS band_" << (i + 1);
+    }
+    sql << " FROM read_parquet(" << SqlSingleQuote(paths[0]) << ") b1";
+    for (size_t i = 1; i < paths.size(); i++) {
+        sql << " FULL OUTER JOIN read_parquet(" << SqlSingleQuote(paths[i])
+            << ") b" << (i + 1) << " USING (block)";
+    }
+    // Filter out the metadata rows (block=0) from each input
+    sql << " WHERE COALESCE(";
+    for (size_t i = 0; i < paths.size(); i++) {
+        if (i > 0) sql << ", ";
+        sql << "b" << (i + 1) << ".block";
+    }
+    sql << ") != 0";
+    sql << " ORDER BY block";
+    return sql.str();
+}
+
+// ─────────────────────────────────────────────
+// Bind: parse list, read metadata from each input, validate, compose,
+// build SQL, set output schema.
+// ─────────────────────────────────────────────
+static unique_ptr<FunctionData> RaquetMergeBandsBind(
+        ClientContext &context, TableFunctionBindInput &input,
+        vector<LogicalType> &return_types, vector<string> &names) {
+
+    if (input.inputs.empty()) {
+        throw InvalidInputException("raquet_merge_bands: missing input list");
+    }
+    auto &list_value = input.inputs[0];
+    if (list_value.IsNull()) {
+        throw InvalidInputException("raquet_merge_bands: input list cannot be NULL");
+    }
+
+    auto &paths_values = ListValue::GetChildren(list_value);
+    if (paths_values.empty()) {
+        throw InvalidInputException("raquet_merge_bands: input list is empty");
+    }
+
+    auto bind_data = make_uniq<RaquetMergeBandsBindData>();
+    bind_data->input_paths.reserve(paths_values.size());
+    for (const auto &v : paths_values) {
+        if (v.IsNull()) {
+            throw InvalidInputException("raquet_merge_bands: input list contains NULL paths");
+        }
+        bind_data->input_paths.push_back(v.GetValue<std::string>());
+    }
+
+    // Read metadata rows from each input via Connection.
+    auto jsons = ReadMetadataJsons(context, bind_data->input_paths);
+
+    // Validate + compose merged metadata.
+    bind_data->merged_metadata = MergeMetadata(bind_data->input_paths, jsons);
+
+    // Build the data-join SQL string for InitGlobal to execute.
+    bind_data->join_sql = BuildJoinSQL(bind_data->input_paths);
+
+    // Output schema: block, metadata, band_1..band_N.
+    names.push_back("block");      return_types.push_back(LogicalType::UBIGINT);
+    names.push_back("metadata");   return_types.push_back(LogicalType::VARCHAR);
+    for (size_t i = 0; i < bind_data->input_paths.size(); i++) {
+        names.push_back("band_" + std::to_string(i + 1));
+        return_types.push_back(LogicalType::BLOB);
+    }
+    bind_data->column_names = names;
+    return std::move(bind_data);
+}
+
+// ─────────────────────────────────────────────
+// InitGlobal: open a Connection, run the join SQL, store streaming result.
+// ─────────────────────────────────────────────
+static unique_ptr<GlobalTableFunctionState> RaquetMergeBandsInitGlobal(
+        ClientContext &context, TableFunctionInitInput &input) {
+    auto &bind = input.bind_data->Cast<RaquetMergeBandsBindData>();
+    auto state = make_uniq<RaquetMergeBandsGlobalState>();
+
+    state->connection = std::unique_ptr<Connection>(new Connection(*context.db));
+    state->result = state->connection->Query(bind.join_sql);
+    if (state->result->HasError()) {
+        throw InvalidInputException(
+            "raquet_merge_bands: data-join query failed: %s",
+            state->result->GetError());
+    }
+    return std::move(state);
+}
+
+// ─────────────────────────────────────────────
+// Execute: emit metadata row first, then stream chunks from the join
+// QueryResult into the output DataChunk.
+// ─────────────────────────────────────────────
+static void RaquetMergeBandsExecute(ClientContext &context, TableFunctionInput &input,
+                                     DataChunk &output) {
+    auto &bind = input.bind_data->Cast<RaquetMergeBandsBindData>();
+    auto &state = input.global_state->Cast<RaquetMergeBandsGlobalState>();
+
+    if (state.finished) {
+        output.SetCardinality(0);
+        return;
+    }
+
+    idx_t out_row = 0;
+    idx_t max_rows = STANDARD_VECTOR_SIZE;
+    idx_t band_count = bind.input_paths.size();
+
+    // Phase 1: emit metadata row exactly once
+    if (!state.metadata_emitted) {
+        FlatVector::GetData<uint64_t>(output.data[0])[out_row] = 0;
+        FlatVector::GetData<string_t>(output.data[1])[out_row] =
+            StringVector::AddString(output.data[1], bind.merged_metadata);
+        for (idx_t i = 0; i < band_count; i++) {
+            FlatVector::SetNull(output.data[2 + i], out_row, true);
+        }
+        out_row++;
+        state.metadata_emitted = true;
+    }
+
+    // Phase 2: stream from the join QueryResult
+    while (out_row < max_rows) {
+        if (!state.current_chunk || state.current_row >= state.current_chunk->size()) {
+            state.current_chunk = state.result->Fetch();
+            state.current_row = 0;
+            if (!state.current_chunk || state.current_chunk->size() == 0) {
+                state.finished = true;
+                break;
+            }
+        }
+        // Copy one row from current_chunk into output
+        for (idx_t col = 0; col < band_count + 2; col++) {
+            // Use Vector::SetValue/GetValue for safety; performance is
+            // acceptable since each row is small (one UBIGINT + one
+            // VARCHAR + N BLOBs, all already in memory).
+            Value v = state.current_chunk->GetValue(col, state.current_row);
+            output.SetValue(col, out_row, v);
+        }
+        out_row++;
+        state.current_row++;
+    }
+
+    output.SetCardinality(out_row);
+}
+
+// ─────────────────────────────────────────────
+// Cardinality estimate
+// ─────────────────────────────────────────────
+static unique_ptr<NodeStatistics> RaquetMergeBandsCardinality(
+        ClientContext &context, const FunctionData *bind_data_p) {
+    // We don't know the joined row count without scanning. Provide a
+    // rough estimate based on the first input's row count.
+    auto &bind = bind_data_p->Cast<RaquetMergeBandsBindData>();
+    if (bind.input_paths.empty()) {
+        return make_uniq<NodeStatistics>();
+    }
+    Connection con(*context.db);
+    auto q = "SELECT COUNT(*) FROM read_parquet(" +
+             SqlSingleQuote(bind.input_paths[0]) + ") WHERE block != 0";
+    auto result = con.Query(q);
+    if (result->HasError() || !result) {
+        return make_uniq<NodeStatistics>();
+    }
+    auto chunk = result->Fetch();
+    if (!chunk || chunk->size() == 0) {
+        return make_uniq<NodeStatistics>();
+    }
+    int64_t n = chunk->GetValue(0, 0).GetValue<int64_t>();
+    return make_uniq<NodeStatistics>(static_cast<idx_t>(n + 1));
+}
+
+// ─────────────────────────────────────────────
+// Registration
+// ─────────────────────────────────────────────
+void RegisterMergeBandsFunction(ExtensionLoader &loader) {
+    TableFunction merge_fn(
+        "raquet_merge_bands",
+        {LogicalType::LIST(LogicalType::VARCHAR)},
+        RaquetMergeBandsExecute,
+        RaquetMergeBandsBind,
+        RaquetMergeBandsInitGlobal);
+    merge_fn.cardinality = RaquetMergeBandsCardinality;
+    loader.RegisterFunction(merge_fn);
+}
+
+}  // namespace duckdb

--- a/test/sql/merge_bands.test
+++ b/test/sql/merge_bands.test
@@ -1,0 +1,213 @@
+# name: test/sql/merge_bands.test
+# description: raquet_merge_bands(LIST<VARCHAR>) — combine N single-band raquets
+#              into a multi-band raquet. Covers happy path for both metadata
+#              formats (v0.1.0 flat / v0.5.0 nested tiling), the recompute of
+#              num_blocks, band renaming + source_band renumbering, and the
+#              negative paths (multi-band input rejection, empty list,
+#              spatial-frame mismatch).
+# group: [raquet]
+
+require raquet
+
+require parquet
+
+require json
+
+# =============================================================================
+# Setup: produce single-band raquets from test_palette.tif (16×16, uint8,
+# single band) in both v0.5.0 (default) and v0 metadata formats. Since the
+# fixture has only one source band, the per-band raquets are byte-equivalent;
+# they're used here as N independent inputs to exercise the merge mechanics.
+# =============================================================================
+
+statement ok
+COPY (SELECT * FROM read_raster('test/data/test_palette.tif', bands='1'))
+TO 'duckdb_unittest_tempdir/mb_v050_a.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT * FROM read_raster('test/data/test_palette.tif', bands='1'))
+TO 'duckdb_unittest_tempdir/mb_v050_b.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT * FROM read_raster('test/data/test_palette.tif', bands='1'))
+TO 'duckdb_unittest_tempdir/mb_v050_c.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT * FROM read_raster('test/data/test_palette.tif', bands='1', format='v0'))
+TO 'duckdb_unittest_tempdir/mb_v0_a.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (SELECT * FROM read_raster('test/data/test_palette.tif', bands='1', format='v0'))
+TO 'duckdb_unittest_tempdir/mb_v0_b.parquet' (FORMAT PARQUET);
+
+# =============================================================================
+# v0.5.0 (default) — 3-band merge
+# =============================================================================
+
+statement ok
+CREATE TABLE merged_v050 AS
+SELECT * FROM raquet_merge_bands([
+  'duckdb_unittest_tempdir/mb_v050_a.parquet',
+  'duckdb_unittest_tempdir/mb_v050_b.parquet',
+  'duckdb_unittest_tempdir/mb_v050_c.parquet'
+])
+
+# Schema: block, metadata, band_1, band_2, band_3
+query I
+SELECT count(*) FROM information_schema.columns WHERE table_name = 'merged_v050'
+----
+5
+
+# Version preserved from inputs
+query I
+SELECT json_extract_string(metadata, '$.version') FROM merged_v050 WHERE block = 0
+----
+0.5.0
+
+# Output uses v0.5.0 nested-tiling shape (key test for the parse_metadata
+# round-trip — pre-refactor, the splice approach silently no-op'd on
+# nested fields).
+query I
+SELECT metadata LIKE '%"tiling"%' FROM merged_v050 WHERE block = 0
+----
+true
+
+# Band names renumbered to output position
+query III
+SELECT json_extract_string(metadata, '$.bands[0].name'),
+       json_extract_string(metadata, '$.bands[1].name'),
+       json_extract_string(metadata, '$.bands[2].name')
+FROM merged_v050 WHERE block = 0
+----
+band_1	band_2	band_3
+
+# source_band renumbered to output position (1..N), independent of each
+# input's original source_band. Critical: regression test for the dedicated
+# fix-commit on the original PR.
+query III
+SELECT json_extract(metadata, '$.bands[0].source_band')::INT,
+       json_extract(metadata, '$.bands[1].source_band')::INT,
+       json_extract(metadata, '$.bands[2].source_band')::INT
+FROM merged_v050 WHERE block = 0
+----
+1	2	3
+
+# num_blocks recomputed and emitted under tiling. Pre-refactor, the splice
+# approach matched only top-level keys (depth=1) and silently no-op'd here,
+# leaving input 0's count in place — this assertion catches that regression.
+query I
+SELECT json_extract(metadata, '$.tiling.num_blocks')::INT = (SELECT count(*) FROM merged_v050 WHERE block != 0)
+FROM merged_v050 WHERE block = 0
+----
+true
+
+# Bounds preserved (was unreachable through the splice path; now exercised
+# via the parse_metadata round-trip).
+query I
+SELECT json_array_length(json_extract(metadata, '$.bounds'))
+FROM merged_v050 WHERE block = 0
+----
+4
+
+# Per-band properties (colortable, STATISTICS_*) survive the round-trip
+query I
+SELECT json_array_length(json_extract(metadata, '$.bands[1].colortable."1"'))
+FROM merged_v050 WHERE block = 0
+----
+4
+
+# =============================================================================
+# v0.1.0 ("v0") — 2-band merge
+# =============================================================================
+
+statement ok
+CREATE TABLE merged_v0 AS
+SELECT * FROM raquet_merge_bands([
+  'duckdb_unittest_tempdir/mb_v0_a.parquet',
+  'duckdb_unittest_tempdir/mb_v0_b.parquet'
+])
+
+# Version preserved from v0 inputs
+query I
+SELECT json_extract_string(metadata, '$.version') FROM merged_v0 WHERE block = 0
+----
+0.1.0
+
+# Output uses v0 flat shape (no nested tiling object)
+query I
+SELECT metadata LIKE '%"tiling"%' FROM merged_v0 WHERE block = 0
+----
+false
+
+# v0 has flat top-level num_blocks. Recomputed correctly here.
+query I
+SELECT json_extract(metadata, '$.num_blocks')::INT = (SELECT count(*) FROM merged_v0 WHERE block != 0)
+FROM merged_v0 WHERE block = 0
+----
+true
+
+# v0 emits top-level "nodata" as an array of N entries (one per band) for
+# multi-band outputs. Regression test for the original "quoted-string vs
+# numeric" issue called out in the manual-fix commit.
+query I
+SELECT json_array_length(json_extract(metadata, '$.nodata'))
+FROM merged_v0 WHERE block = 0
+----
+2
+
+# bands[i].source_band renumbered to output position (1, 2) in v0 too
+query II
+SELECT json_extract(metadata, '$.bands[0].source_band')::INT,
+       json_extract(metadata, '$.bands[1].source_band')::INT
+FROM merged_v0 WHERE block = 0
+----
+1	2
+
+# =============================================================================
+# Negative paths
+# =============================================================================
+
+# Empty list → InvalidInputException at bind time
+statement error
+SELECT * FROM raquet_merge_bands(CAST([] AS VARCHAR[]))
+----
+input list is empty
+
+# NULL list → InvalidInputException
+statement error
+SELECT * FROM raquet_merge_bands(CAST(NULL AS VARCHAR[]))
+----
+input list cannot be NULL
+
+# Multi-band input rejection: feed a previously-merged 2-band raquet back
+# into raquet_merge_bands. test_palette.tif has only one source band so
+# we can't produce a multi-band raquet directly via `bands=` (which dedups
+# duplicate indices); instead we reuse the v050 merged output as input.
+statement ok
+COPY merged_v050
+TO 'duckdb_unittest_tempdir/mb_multi.parquet' (FORMAT PARQUET);
+
+statement error
+SELECT * FROM raquet_merge_bands([
+  'duckdb_unittest_tempdir/mb_multi.parquet',
+  'duckdb_unittest_tempdir/mb_v050_a.parquet'
+])
+----
+only single-band inputs are supported
+
+# Spatial-frame mismatch: produce an input at a different zoom range so
+# min_zoom/max_zoom differs, then attempt to merge. Pre-refactor, this would
+# have silently composed corrupt output on v0.5.0 inputs (the splice path
+# only looked at depth-1 keys, missing the nested min_zoom/max_zoom). The
+# parse_metadata round-trip catches it at struct-comparison time.
+statement ok
+COPY (SELECT * FROM read_raster('test/data/test_palette.tif', bands='1', max_zoom=5))
+TO 'duckdb_unittest_tempdir/mb_v050_diff_zoom.parquet' (FORMAT PARQUET);
+
+statement error
+SELECT * FROM raquet_merge_bands([
+  'duckdb_unittest_tempdir/mb_v050_a.parquet',
+  'duckdb_unittest_tempdir/mb_v050_diff_zoom.parquet'
+])
+----
+must share the same spatial frame


### PR DESCRIPTION
> **Merge order: this PR depends on #7 and #8. Merge in order: #7 → #8 → #9.**

## Summary

Adds a new table function `raquet_merge_bands(LIST<VARCHAR>)` that takes N single-band raquet parquet paths and returns the merged multi-band raquet content (one metadata row at `block=0` with composed multi-band metadata, plus joined data rows where each input's `band_1` maps to the corresponding output `band_i` column).

This closes the **per-band-then-merge workflow** that's the practical answer to multi-band conversions on memory-constrained hardware. The companion #7 already provides the per-band conversion side via `bands='N'`; this PR provides the merge side.

## Usage

```sql
COPY (SELECT * FROM raquet_merge_bands([
    'b1.parquet', 'b2.parquet', 'b3.parquet', 'b4.parquet', 'b5.parquet'
])) TO 'merged.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 20000);
```

Output schema: `block UBIGINT, metadata VARCHAR, band_1 BLOB, band_2 BLOB, …, band_N BLOB`.

## What "merged" means

Modeled on `gdalbuildvrt -separate`. Inputs must agree on the spatial frame; band metadata is concatenated and renumbered.

| Field | Required match? | Behavior in output |
|---|---|---|
| `version`, `compression`, `block_width`, `block_height`, `block_resolution`, `bounds`, `width`, `height`, `band[0].type`, `min_zoom`/`minresolution`, `max_zoom`/`maxresolution` | exact | kept from input 0 (validated to match) |
| `bands[i]` | differs by definition | each input's `bands[0]` preserved (stats, colorinterp, colortable, description), with `name` and `source_band` renumbered to the output position (`i+1`) |
| `nodata` | may differ per band | array form `[nd_1, …, nd_N]` |
| `num_blocks` | recomputed | count of distinct `block` values in the joined output, plus 1 for the metadata row |

Mismatches raise `InvalidInputException` with both paths and the conflicting values.

## Implementation

| Concern | Approach |
|---|---|
| **Metadata parsing** | Hand-rolled minimal JSON parser (~150 lines). Sufficient for the well-defined raquet metadata shape that we ourselves write. |
| **Validation** | Compare extracted raw values across inputs; throw on mismatch with precise field name + paths + values. |
| **Metadata composition** | Substring splicing: take input 0's full metadata, replace top-level `bands` with renumbered concatenation, replace `nodata` scalar with array, recompute `num_blocks`. Preserves all per-band sub-fields (stats, colortable, etc.) without re-encoding. |
| **Data merge** | Delegated to DuckDB SQL via an internal `Connection`: a `FULL OUTER JOIN` on `block` across N `read_parquet()` calls, ordered by block, streamed back into the table function output. Reuses DuckDB's parallel hash join — no reimplementation in C++. |

Bind reads each input's metadata row, validates compatibility, composes the merged JSON, and builds the join SQL string. InitGlobal launches the join as a streaming `QueryResult`. Execute emits the metadata row first, then pulls chunks from the QueryResult into the output DataChunk.

## Verification

- **2-band end-to-end** on real fixtures (`full_b1.parquet`, `full_b2.parquet`): 93,642 data rows, source_bands [1, 2] preserved, `nodata` array, `num_bands=2`, schema `block, metadata, band_1, band_2`.
- **5-band end-to-end** on real fixtures (the 5 single-band parquets we produced earlier): **94,538 data rows**, source_bands renumbered to [1..5], per-band stats / colortable / colorinterp preserved, `nodata` array of 5, all 5 columns populated correctly. **Wall: 16.6 s** for 1.1 GB output.
- **4-band drop-and-merge** (`raquet_merge_bands(['full_b2', 'full_b3', 'full_b4', 'full_b5'])`): 94,538 data rows, source_bands [1..4]; verified end-to-end through BigQuery upload.
- **Schema introspection** via `DESCRIBE SELECT * FROM raquet_merge_bands(...)` — produces the right column count and types based on the input list length.
- **Negative test** (different `bounds` between inputs):
  ```
  Invalid Input Error: raquet_merge_bands: 'bounds' differs between
    'yc_b25.parquet' ([-92,14,-78,24]) and 'full_b1.parquet'
    ([-180,-60,180,80]) — all inputs must share the same spatial frame
  ```

## Documentation

`README.md` — new `### raquet_merge_bands` section under Function Reference covering the LIST<VARCHAR> input shape, bind-time validation list, output schema, and the typical per-band → merge workflow (including the band-drop variant).

## Relationship to other PRs

- **Depends on #7** for the `BandInfo.source_band` field and the bands-filter functionality (verified by reading metadata produced by `bands='N'`-converted parquets). Branched off `feat/sparsity-aware-tiles`.
- **Depends on #8** (rebased on top of it). Both #8 and #9 need the rename and the new code in the same file tree.