### PR TITLE
ci: cut workflow runtime ~72m → ~3m (drop duplicate build, add ccache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build zlib1g-dev
 
+    # Mirrors the ccache strategy used by upstream DuckDB's extension CI
+    # template (extension-ci-tools/.github/workflows/_extension_distribution.yml):
+    # restore a per-OS ccache between runs so DuckDB's source tree (which
+    # accounts for the bulk of the compile work) is not rebuilt from scratch
+    # on every PR. DuckDB's CMakeLists auto-detects ccache via find_program,
+    # so having it on PATH at configure time is enough — no extra cmake flags
+    # are required.
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -109,6 +116,13 @@ jobs:
       run: |
         brew install cmake ninja
 
+    # Mirrors the ccache strategy used by upstream DuckDB's extension CI
+    # template (extension-ci-tools/.github/workflows/_extension_distribution.yml):
+    # restore a per-OS ccache between runs so DuckDB's source tree (which
+    # accounts for the bulk of the compile work) is not rebuilt from scratch
+    # on every PR. DuckDB's CMakeLists auto-detects ccache via find_program,
+    # so having it on PATH at configure time is enough — no extra cmake flags
+    # are required.
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build zlib1g-dev
 
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-${{ runner.os }}
+        max-size: 1G
+
     - name: Build extension (Release)
       run: |
         # actions/checkout@v4 fetches the duckdb submodule shallowly by default,
@@ -102,6 +108,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew install cmake ninja
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-${{ runner.os }}
+        max-size: 1G
 
     - name: Build extension (Release)
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,49 @@ jobs:
       run: |
         make test
 
+    - name: Test with sample data
+      run: |
+        ./build/release/duckdb -c "
+          INSTALL json;
+          LOAD json;
+          LOAD 'build/release/extension/raquet/raquet.duckdb_extension';
+
+          -- Test basic query
+          SELECT count(*) as total_rows FROM read_parquet('test_data/raquet_test.parquet');
+
+          -- Test metadata extraction
+          SELECT
+            json_extract_string(metadata, '$.compression') as compression,
+            json_extract_string(metadata, '$.block_width') as block_width
+          FROM read_parquet('test_data/raquet_test.parquet')
+          WHERE block = 0;
+
+          -- Test QUADBIN functions. DuckDB 1.5.2's parser rejects
+          -- (struct_returning_func()).*; use explicit field accessors
+          -- against the STRUCT(min_lon, min_lat, max_lon, max_lat) returned
+          -- by quadbin_to_bbox.
+          SELECT
+            block,
+            quadbin_resolution(block) as zoom,
+            (quadbin_to_bbox(block)).min_lon as min_lon,
+            (quadbin_to_bbox(block)).min_lat as min_lat,
+            (quadbin_to_bbox(block)).max_lon as max_lon,
+            (quadbin_to_bbox(block)).max_lat as max_lat
+          FROM read_parquet('test_data/raquet_test.parquet')
+          WHERE block != 0
+          LIMIT 3;
+
+          -- Test pixel extraction
+          SELECT
+            block,
+            raquet_pixel(band_1, 'uint8', 128, 128, 256, 'gzip') as pixel_value
+          FROM read_parquet('test_data/raquet_test.parquet')
+          WHERE block != 0
+          LIMIT 3;
+
+          SELECT 'All tests passed!' as status;
+        "
+
     - name: Upload build artifacts
       if: always()
       uses: actions/upload-artifact@v4
@@ -84,68 +127,3 @@ jobs:
         path: build/release/extension/raquet/raquet.duckdb_extension
         if-no-files-found: warn
 
-  test-with-sample-data:
-    name: Test with Sample Data
-    runs-on: ubuntu-latest
-    needs: build-linux
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake ninja-build zlib1g-dev curl
-
-    - name: Build extension
-      run: |
-        # See note in build-linux job for why OVERRIDE_GIT_DESCRIBE is needed.
-        export OVERRIDE_GIT_DESCRIBE="v1.5.2-0-g$(cd duckdb && git rev-parse --short=10 HEAD)"
-        echo "OVERRIDE_GIT_DESCRIBE=$OVERRIDE_GIT_DESCRIBE"
-        make release
-
-    - name: Test with sample data
-      run: |
-        ./build/release/duckdb -c "
-          INSTALL json;
-          LOAD json;
-          LOAD 'build/release/extension/raquet/raquet.duckdb_extension';
-
-          -- Test basic query
-          SELECT count(*) as total_rows FROM read_parquet('test_data/raquet_test.parquet');
-
-          -- Test metadata extraction
-          SELECT
-            json_extract_string(metadata, '$.compression') as compression,
-            json_extract_string(metadata, '$.block_width') as block_width
-          FROM read_parquet('test_data/raquet_test.parquet')
-          WHERE block = 0;
-
-          -- Test QUADBIN functions. DuckDB 1.5.2's parser rejects
-          -- (struct_returning_func()).*; use explicit field accessors
-          -- against the STRUCT(min_lon, min_lat, max_lon, max_lat) returned
-          -- by quadbin_to_bbox.
-          SELECT
-            block,
-            quadbin_resolution(block) as zoom,
-            (quadbin_to_bbox(block)).min_lon as min_lon,
-            (quadbin_to_bbox(block)).min_lat as min_lat,
-            (quadbin_to_bbox(block)).max_lon as max_lon,
-            (quadbin_to_bbox(block)).max_lat as max_lat
-          FROM read_parquet('test_data/raquet_test.parquet')
-          WHERE block != 0
-          LIMIT 3;
-
-          -- Test pixel extraction
-          SELECT
-            block,
-            raquet_pixel(band_1, 'uint8', 128, 128, 256, 'gzip') as pixel_value
-          FROM read_parquet('test_data/raquet_test.parquet')
-          WHERE block != 0
-          LIMIT 3;
-
-          SELECT 'All tests passed!' as status;
-        "


### PR DESCRIPTION
## Summary

- Inline the sample-data smoke test into the `build-linux` job and remove the standalone `test-with-sample-data` job. That job was re-running `make release` even though it `needs: build-linux`, burning ~35 min on a duplicate build. Follows the same pattern DuckDB's own extension CI uses (`extension-ci-tools/.github/workflows/_extension_distribution.yml`): build and test in the same job so the test step uses the freshly built files in the workspace directly.
- Add `hendrikmuhs/ccache-action` to both `build-linux` and `build-macos`. DuckDB's CMakeLists already auto-detects ccache via `find_program`, so having ccache on PATH is enough. The bulk of compile time is DuckDB itself, which barely changes between PRs — after the first run seeds the cache, subsequent builds reuse nearly every object file.

## Measured runtime impact

| Stage | Before (PR #11, run 25690117349) | After, warm cache (run 25696997425) |
|---|---|---|
| Build (Linux) | 35m 48s | **2m 44s** |
| Build (macOS) | 28m 33s | **2m 56s** |
| Test with Sample Data | 36m 43s | removed |
| **Total wall time** | **~72m** | **~3m** |

## Test plan

- [x] CI runs green on this PR (cold-cache run + inlined smoke test).
- [x] Push another commit and confirm warm-cache run drops Linux build to <5m. Measured: 2m 44s.
- [x] macOS build passes; cache restore works on `macos-latest`. Measured: 2m 56s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)