### PR TITLE
feat: WGS84 / GoogleCRS84Quad tile matrix set support in read_raster()

### DIFF
--- a/src/include/quadbin.hpp
+++ b/src/include/quadbin.hpp
@@ -283,6 +283,110 @@ inline void cell_siblings(uint64_t cell, uint64_t siblings[4]) {
     cell_to_children(parent, siblings);
 }
 
+// ─────────────────────────────────────────────
+// Tile Matrix Set abstraction
+//
+// A QUADBIN cell is a pure quadkey (z/x/y packed into 64 bits) — the cell
+// algebra above (tile_to_cell / cell_to_tile / parent / children / kring) is
+// projection-agnostic and shared by every TMS. What differs per TMS is only
+// the mapping between cells and geographic coordinates.
+//
+// The free functions above ARE the WebMercatorQuad mapping; WebMercatorQuad
+// here delegates to them, so its output is byte-identical to the legacy code
+// path (this is the P1 regression guarantee). GoogleCRS84Quad adds a
+// single-root, square-grid, plate-carrée (CRS84) mapping over
+// [-180,180]×[-90,90] — anisotropic pixels, but QUADBIN bit-compatible.
+//
+// Only the producer-side conversions needed by read_raster() are modelled
+// here (lonlat→tile, tile→bbox, world span / max latitude / target SRS).
+// Read-side helpers (lonlat_to_pixel, cell_to_lonlat, …) remain
+// WebMercator-only for now; teaching them about the TMS is consumer-side work.
+// ─────────────────────────────────────────────
+enum class TmsId { WebMercatorQuad, GoogleCRS84Quad };
+
+struct TileMatrixSet {
+    TmsId id = TmsId::WebMercatorQuad;
+
+    // Map a metadata tile_matrix_set string to a TMS. Unknown / empty values
+    // fall back to WebMercatorQuad (back-compat with pre-0.6.0 files).
+    static TileMatrixSet FromName(const std::string &name) {
+        if (name == "GoogleCRS84Quad") return TileMatrixSet{TmsId::GoogleCRS84Quad};
+        return TileMatrixSet{TmsId::WebMercatorQuad};
+    }
+
+    const char *name() const {
+        return id == TmsId::GoogleCRS84Quad ? "GoogleCRS84Quad" : "WebMercatorQuad";
+    }
+    const char *uri() const {
+        return id == TmsId::GoogleCRS84Quad
+            ? "http://www.opengis.net/def/tilematrixset/OGC/1.0/GoogleCRS84Quad"
+            : "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad";
+    }
+    // CRS the tile grid (cell coordinates / geotransform) is expressed in.
+    const char *crs() const {
+        return id == TmsId::GoogleCRS84Quad ? "OGC:CRS84" : "EPSG:3857";
+    }
+    // EPSG code used to build the GDAL warp-target SRS.
+    int target_epsg() const {
+        return id == TmsId::GoogleCRS84Quad ? 4326 : 3857;
+    }
+    double max_latitude() const {
+        return id == TmsId::GoogleCRS84Quad ? 90.0 : MAX_LATITUDE;
+    }
+    // Span of the world along X in the grid CRS units — metres (full equatorial
+    // circumference) for WebMercator, degrees (360) for CRS84. Drives zoom calc.
+    double world_span_x() const {
+        return id == TmsId::GoogleCRS84Quad ? 360.0 : (2.0 * PI * EARTH_RADIUS);
+    }
+
+    void lonlat_to_tile(double lon, double lat, int z, int &x, int &y) const {
+        if (id == TmsId::WebMercatorQuad) {
+            quadbin::lonlat_to_tile(lon, lat, z, x, y);
+            return;
+        }
+        // GoogleCRS84Quad: plate carrée, single root, square 2^z × 2^z grid.
+        double ml = max_latitude();
+        if (lat > ml) lat = ml;
+        if (lat < -ml) lat = -ml;
+        double n = std::pow(2.0, z);
+        x = static_cast<int>(std::floor((lon + 180.0) / 360.0 * n));
+        y = static_cast<int>(std::floor((90.0 - lat) / 180.0 * n));
+        if (x < 0) x = 0;
+        if (x >= static_cast<int>(n)) x = static_cast<int>(n) - 1;
+        if (y < 0) y = 0;
+        if (y >= static_cast<int>(n)) y = static_cast<int>(n) - 1;
+    }
+
+    // Tile bounds in the grid CRS (metres for WebMercator, degrees for CRS84).
+    // Used to set the warp tile geotransform.
+    void tile_to_bbox_projected(int x, int y, int z,
+                                double &min_x, double &min_y,
+                                double &max_x, double &max_y) const {
+        if (id == TmsId::WebMercatorQuad) {
+            quadbin::tile_to_bbox_mercator(x, y, z, min_x, min_y, max_x, max_y);
+            return;
+        }
+        double n = std::pow(2.0, z);
+        min_x = x / n * 360.0 - 180.0;
+        max_x = (x + 1) / n * 360.0 - 180.0;
+        // Y increases downward in tile space; row 0 is the north edge (+90).
+        max_y = 90.0 - y / n * 180.0;
+        min_y = 90.0 - (y + 1) / n * 180.0;
+    }
+
+    // Tile bounds in WGS84 degrees (metadata bounds, intersection tests).
+    void tile_to_bbox_wgs84(int x, int y, int z,
+                            double &min_lon, double &min_lat,
+                            double &max_lon, double &max_lat) const {
+        if (id == TmsId::WebMercatorQuad) {
+            quadbin::tile_to_bbox_wgs84(x, y, z, min_lon, min_lat, max_lon, max_lat);
+            return;
+        }
+        // CRS84: the projected bbox is already in degrees.
+        tile_to_bbox_projected(x, y, z, min_lon, min_lat, max_lon, max_lat);
+    }
+};
+
 // Calculate pixel coordinates within a tile for a given lon/lat
 inline void lonlat_to_pixel(double lon, double lat, int z, int tile_size,
                             int &pixel_x, int &pixel_y, int &tile_x, int &tile_y) {

--- a/src/include/raquet_metadata.hpp
+++ b/src/include/raquet_metadata.hpp
@@ -83,7 +83,13 @@ struct RaquetMetadata {
     int pixel_zoom;     // new in v0.3.0
     int num_blocks;
     std::string scheme; // "quadbin"
-    std::string crs;    // "EPSG:3857"
+    std::string crs;    // "EPSG:3857" (WebMercatorQuad) or "OGC:CRS84" (GoogleCRS84Quad)
+    // v0.6.0: OGC Tile Matrix Set that georeferences the QUADBIN cells.
+    // "WebMercatorQuad" (default / pre-0.6.0 files) or "GoogleCRS84Quad".
+    // The cell bits are identical across TMSs; this field tells consumers how
+    // to map them to geographic coordinates — without it, a non-Mercator file
+    // is silently misread as Web Mercator.
+    std::string tile_matrix_set = "WebMercatorQuad";
     bool tile_statistics;              // v0.5.0: pre-computed per-tile stats
     std::vector<std::string> tile_statistics_columns; // v0.5.0: which stats are available
     std::vector<BandInfo> band_info;  // Full band info including nodata
@@ -388,8 +394,13 @@ struct RaquetMetadata {
     std::string to_json() const {
         std::string json = "{";
         json += "\"file_format\":\"raquet\"";
-        json += ",\"version\":\"0.5.0\"";
+        json += ",\"version\":\"0.6.0\"";
         json += ",\"crs\":\"" + crs + "\"";
+        // v0.6.0: declare the Tile Matrix Set so consumers georeference cells
+        // correctly. Defaults to WebMercatorQuad for parity with pre-0.6.0
+        // (Mercator-only) files.
+        json += ",\"tile_matrix_set\":\"" +
+            (tile_matrix_set.empty() ? std::string("WebMercatorQuad") : tile_matrix_set) + "\"";
 
         // Bounds
         json += ",\"bounds\":[" +
@@ -937,6 +948,11 @@ inline RaquetMetadata parse_metadata(const std::string &json) {
     if (meta.band_layout.empty()) meta.band_layout = "sequential";
 
     meta.crs = extract_json_string(json, "crs");
+
+    // v0.6.0: tile_matrix_set. Absent (≤0.5.0 files) → WebMercatorQuad, so
+    // every legacy Mercator file keeps reading correctly.
+    meta.tile_matrix_set = extract_json_string(json, "tile_matrix_set");
+    if (meta.tile_matrix_set.empty()) meta.tile_matrix_set = "WebMercatorQuad";
 
     // Detect version: v0 has no "version" field, v0.5.0+ has it
     std::string version = extract_json_string(json, "version");

--- a/src/metadata/raquet_metadata.cpp
+++ b/src/metadata/raquet_metadata.cpp
@@ -106,9 +106,25 @@ static void RaquetValidateMetadataFunction(DataChunk &args, ExpressionState &sta
                 warnings.push_back("Unknown band_layout: " + meta.band_layout);
             }
 
-            // Validate CRS
-            if (meta.crs != "EPSG:3857" && !meta.crs.empty()) {
-                warnings.push_back("Non-standard CRS: " + meta.crs + " (expected EPSG:3857)");
+            // Validate tile_matrix_set + CRS consistency (v0.6.0). The CRS the
+            // tile grid is expressed in is determined by the TMS; warn when it
+            // disagrees. Unknown TMS values are flagged but not fatal.
+            std::string expected_crs;
+            if (meta.tile_matrix_set == "WebMercatorQuad") {
+                expected_crs = "EPSG:3857";
+            } else if (meta.tile_matrix_set == "GoogleCRS84Quad") {
+                expected_crs = "OGC:CRS84";
+            } else if (!meta.tile_matrix_set.empty()) {
+                warnings.push_back("Unknown tile_matrix_set: " + meta.tile_matrix_set);
+            }
+            if (!expected_crs.empty() && !meta.crs.empty() && meta.crs != expected_crs) {
+                // Accept EPSG:4326 as an alias of OGC:CRS84 (same lon/lat datum).
+                bool crs84_alias = (expected_crs == "OGC:CRS84" &&
+                                    (meta.crs == "EPSG:4326" || meta.crs == "OGC:CRS84"));
+                if (!crs84_alias) {
+                    warnings.push_back("CRS " + meta.crs + " does not match tile_matrix_set " +
+                                       meta.tile_matrix_set + " (expected " + expected_crs + ")");
+                }
             }
         }
 

--- a/src/raster/read_raster.cpp
+++ b/src/raster/read_raster.cpp
@@ -169,6 +169,15 @@ struct ReadRasterBindData : public TableFunctionData {
     std::string overviews = "auto";
     std::string zoom_strategy = "auto"; // auto, lower, upper
     std::string output_format = "v0.5.0"; // v0 or v0.5.0
+    // v0.6.0: target Tile Matrix Set. "WebMercatorQuad" (default, EPSG:3857)
+    // or "GoogleCRS84Quad" (CRS84 plate carrée). Determines warp target SRS,
+    // tile geotransform, zoom calc, and the emitted crs/tile_matrix_set.
+    std::string tile_matrix_set = "WebMercatorQuad";
+
+    // Resolve the parsed string to the TMS strategy (quadbin.hpp).
+    quadbin::TileMatrixSet Tms() const {
+        return quadbin::TileMatrixSet::FromName(tile_matrix_set);
+    }
 
     // Sparsity-aware tile pipeline
     SparsityProbe sparsity_probe = SparsityProbe::Auto;
@@ -377,11 +386,13 @@ struct ReadRasterLocalState : public LocalTableFunctionState {
 // Helper: Enumerate tiles at a given zoom that intersect bounds
 // ─────────────────────────────────────────────
 static std::vector<RasterTile> EnumerateTiles(double minlon, double minlat,
-                                               double maxlon, double maxlat, int zoom) {
+                                               double maxlon, double maxlat, int zoom,
+                                               const quadbin::TileMatrixSet &tms =
+                                                   quadbin::TileMatrixSet{}) {
     std::vector<RasterTile> tiles;
     int min_tx, min_ty, max_tx, max_ty;
-    quadbin::lonlat_to_tile(minlon, maxlat, zoom, min_tx, min_ty); // NW corner
-    quadbin::lonlat_to_tile(maxlon, minlat, zoom, max_tx, max_ty); // SE corner
+    tms.lonlat_to_tile(minlon, maxlat, zoom, min_tx, min_ty); // NW corner
+    tms.lonlat_to_tile(maxlon, minlat, zoom, max_tx, max_ty); // SE corner
 
     for (int ty = min_ty; ty <= max_ty; ty++) {
         for (int tx = min_tx; tx <= max_tx; tx++) {
@@ -396,11 +407,13 @@ static std::vector<RasterTile> EnumerateTiles(double minlon, double minlat,
 // Thread-safe counter for unique /vsimem/ paths
 static std::atomic<uint64_t> vsimem_counter{0};
 
-static GDALDatasetH CreateTileDataset(GDALDriverH driver, const char *wkt_3857,
+static GDALDatasetH CreateTileDataset(GDALDriverH driver, const char *target_wkt,
                                        const RasterTile &tile, int tile_size,
                                        int band_count, GDALDataType dtype,
                                        double nodata, bool has_nodata,
-                                       std::string &path_out) {
+                                       std::string &path_out,
+                                       const quadbin::TileMatrixSet &tms =
+                                           quadbin::TileMatrixSet{}) {
     // Unique virtual path (atomic counter avoids collisions across threads)
     uint64_t id = vsimem_counter++;
     char path[256];
@@ -412,12 +425,13 @@ static GDALDatasetH CreateTileDataset(GDALDriverH driver, const char *wkt_3857,
         throw IOException("Failed to create in-memory tile dataset for %d/%d/%d", tile.z, tile.x, tile.y);
     }
 
-    // Set CRS
-    GDALSetProjection(ds, wkt_3857);
+    // Set CRS (the TMS grid CRS — EPSG:3857 or CRS84)
+    GDALSetProjection(ds, target_wkt);
 
-    // Set geotransform from tile bounds in Web Mercator
+    // Set geotransform from tile bounds in the TMS grid CRS (metres for
+    // WebMercator, degrees for GoogleCRS84Quad)
     double xmin, ymin, xmax, ymax;
-    quadbin::tile_to_bbox_mercator(tile.x, tile.y, tile.z, xmin, ymin, xmax, ymax);
+    tms.tile_to_bbox_projected(tile.x, tile.y, tile.z, xmin, ymin, xmax, ymax);
     double px_width = (xmax - xmin) / tile_size;
     double px_height = (ymax - ymin) / tile_size;
     double gt[6] = {xmin, px_width, 0, ymax, 0, -px_height};
@@ -902,10 +916,14 @@ static double CalculateResolutionFromMercator(GDALDatasetH ds) {
 // ─────────────────────────────────────────────
 // Helper: Calculate zoom from resolution (matches CLI find_zoom)
 // ─────────────────────────────────────────────
-static int CalculateZoom(double resolution, int block_zoom, const std::string &strategy = "auto") {
-    constexpr double CE = 2.0 * quadbin::PI * quadbin::EARTH_RADIUS; // ~40075016.68
+// world_span is the X extent of the world in the target grid CRS units —
+// the equatorial circumference in metres for WebMercatorQuad (default, keeps
+// the legacy result), or 360 degrees for GoogleCRS84Quad. resolution must be
+// in the same units per pixel.
+static int CalculateZoom(double resolution, int block_zoom, const std::string &strategy = "auto",
+                         double world_span = 2.0 * quadbin::PI * quadbin::EARTH_RADIUS) {
     double tile_dim = std::pow(2.0, block_zoom);
-    double raw_zoom = std::log(CE / tile_dim / resolution) / std::log(2.0);
+    double raw_zoom = std::log(world_span / tile_dim / resolution) / std::log(2.0);
     if (strategy == "lower") {
         return static_cast<int>(std::floor(raw_zoom));
     } else if (strategy == "upper") {
@@ -984,13 +1002,14 @@ static void CalculateBoundsFromMercator(GDALDatasetH ds,
 // Matches CLI find_minzoom()
 // ─────────────────────────────────────────────
 static int CalculateMinZoom(double minlon, double minlat, double maxlon, double maxlat,
-                             int max_zoom, int block_zoom) {
+                             int max_zoom, int block_zoom,
+                             const quadbin::TileMatrixSet &tms = quadbin::TileMatrixSet{}) {
     constexpr int TARGET_MIN_SIZE = 128;
     constexpr int BIG_ZOOM = 32;
 
     int ul_x, ul_y, lr_x, lr_y;
-    quadbin::lonlat_to_tile(minlon, maxlat, BIG_ZOOM, ul_x, ul_y);
-    quadbin::lonlat_to_tile(maxlon, minlat, BIG_ZOOM, lr_x, lr_y);
+    tms.lonlat_to_tile(minlon, maxlat, BIG_ZOOM, ul_x, ul_y);
+    tms.lonlat_to_tile(maxlon, minlat, BIG_ZOOM, lr_x, lr_y);
 
     double high_hypot = std::hypot(static_cast<double>(lr_x - ul_x),
                                     static_cast<double>(lr_y - ul_y));
@@ -1049,6 +1068,19 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
             if (bind_data->output_format != "v0" && bind_data->output_format != "v0.5.0") {
                 throw InvalidInputException("format must be 'v0' or 'v0.5.0'");
             }
+        } else if (kv.first == "tile_matrix_set") {
+            // Case-insensitive match → canonical TMS name. Identifiers are
+            // matched loosely (user may pass "googlecrs84quad") but stored
+            // canonically.
+            auto v = StringUtil::Lower(kv.second.GetValue<string>());
+            if (v == "webmercatorquad") {
+                bind_data->tile_matrix_set = "WebMercatorQuad";
+            } else if (v == "googlecrs84quad") {
+                bind_data->tile_matrix_set = "GoogleCRS84Quad";
+            } else {
+                throw InvalidInputException(
+                    "tile_matrix_set must be 'WebMercatorQuad' or 'GoogleCRS84Quad'");
+            }
         } else if (kv.first == "approx") {
             bind_data->approx_stats = kv.second.GetValue<bool>();
         } else if (kv.first == "sparsity_probe") {
@@ -1105,6 +1137,15 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
                 }
             }
         }
+    }
+
+    // The legacy v0.1.0 metadata format predates the tile_matrix_set field and
+    // is hardwired to Web Mercator; refuse to produce a non-Mercator file in it
+    // (it would carry no TMS marker and silently misrender).
+    if (bind_data->tile_matrix_set != "WebMercatorQuad" && bind_data->output_format == "v0") {
+        throw InvalidInputException(
+            "tile_matrix_set '%s' requires format='v0.5.0' (the v0 format cannot "
+            "declare a tile matrix set)", bind_data->tile_matrix_set);
     }
 
     // Initialize embedded PROJ database and GDAL
@@ -1393,6 +1434,11 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
         }
     }
 
+    // Capture whether zoom was auto (0) before the CRS branches overwrite it,
+    // so the non-Mercator TMS re-derivation below can honor user-set zooms.
+    bool max_zoom_auto = (bind_data->max_zoom == 0);
+    bool min_zoom_auto = (bind_data->min_zoom == 0);
+
     // Fast path: WGS84 and Web Mercator use pure math (no PROJ database needed)
     if (src_is_wgs84 || bind_data->src_is_web_mercator) {
         double resolution;
@@ -1468,6 +1514,33 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
         GDALClose(ds);
     }
 
+    // GoogleCRS84Quad: zoom is relative to the CRS84 (degree) grid, not the
+    // Mercator metres grid. The branches above computed a Mercator-based zoom;
+    // re-derive against the target grid here. Bounds (WGS84 degrees) are
+    // already populated and are TMS-independent, so only zoom changes.
+    {
+        auto tms = bind_data->Tms();
+        if (tms.id == quadbin::TmsId::GoogleCRS84Quad) {
+            double lon_span = bind_data->bounds_maxlon - bind_data->bounds_minlon;
+            double res_deg = lon_span / std::max(1, bind_data->raster_width);
+            if (max_zoom_auto && res_deg > 0.0) {
+                int z = CalculateZoom(res_deg, bind_data->block_zoom,
+                                      bind_data->zoom_strategy, tms.world_span_x());
+                bind_data->max_zoom = std::max(0, std::min(26, z));
+            }
+            if (bind_data->overviews == "none") {
+                bind_data->min_zoom = bind_data->max_zoom;
+            } else if (min_zoom_auto) {
+                bind_data->min_zoom = CalculateMinZoom(
+                    bind_data->bounds_minlon, bind_data->bounds_minlat,
+                    bind_data->bounds_maxlon, bind_data->bounds_maxlat,
+                    bind_data->max_zoom, bind_data->block_zoom, tms);
+            } else if (bind_data->min_zoom > bind_data->max_zoom) {
+                bind_data->min_zoom = bind_data->max_zoom;
+            }
+        }
+    }
+
     // Define output schema
     // Column 1: block (UBIGINT) — QUADBIN cell ID
     names.push_back("block");
@@ -1508,7 +1581,7 @@ static unique_ptr<FunctionData> ReadRasterBind(ClientContext &context,
     // Estimate tile count for cardinality (enables DuckDB parallelism)
     auto est_tiles = EnumerateTiles(bind_data->bounds_minlon, bind_data->bounds_minlat,
                                      bind_data->bounds_maxlon, bind_data->bounds_maxlat,
-                                     bind_data->max_zoom);
+                                     bind_data->max_zoom, bind_data->Tms());
     bind_data->estimated_tiles = est_tiles.size() + 1; // +1 for metadata row
 
     bind_data->column_names = names;
@@ -1561,7 +1634,7 @@ static unique_ptr<GlobalTableFunctionState> ReadRasterInitGlobal(ClientContext &
     state->native_tiles = EnumerateTiles(
         bind_data.bounds_minlon, bind_data.bounds_minlat,
         bind_data.bounds_maxlon, bind_data.bounds_maxlat,
-        bind_data.max_zoom);
+        bind_data.max_zoom, bind_data.Tms());
 
     // Build overview frames if needed. Each thread will warp its share using
     // its own per-thread GDAL handle (local.src_ds), so no global handle is
@@ -1570,7 +1643,7 @@ static unique_ptr<GlobalTableFunctionState> ReadRasterInitGlobal(ClientContext &
         for (int z = bind_data.min_zoom; z < bind_data.max_zoom; z++) {
             auto tiles_at_zoom = EnumerateTiles(
                 bind_data.bounds_minlon, bind_data.bounds_minlat,
-                bind_data.bounds_maxlon, bind_data.bounds_maxlat, z);
+                bind_data.bounds_maxlon, bind_data.bounds_maxlat, z, bind_data.Tms());
             for (auto &tile : tiles_at_zoom) {
                 OverviewFrame frame;
                 frame.tile = tile;
@@ -1651,8 +1724,16 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             throw IOException("Thread failed to open raster: %s", bind_data.filename);
         }
         local.gtiff_driver = GDALGetDriverByName("GTiff");
+        // Warp-target SRS WKT for this TMS (web_mercator_wkt holds the target
+        // grid CRS — EPSG:3857 for WebMercatorQuad, EPSG:4326/CRS84 for
+        // GoogleCRS84Quad). For the geographic target we force lon/lat axis
+        // order to match the (lon, lat) tile geotransform.
+        auto tms = bind_data.Tms();
         OGRSpatialReferenceH srs = OSRNewSpatialReference(nullptr);
-        OSRImportFromEPSG(srs, 3857);
+        OSRImportFromEPSG(srs, tms.target_epsg());
+        if (tms.target_epsg() == 4326) {
+            OSRSetAxisMappingStrategy(srs, OAMS_TRADITIONAL_GIS_ORDER);
+        }
         OSRExportToWkt(srs, &local.web_mercator_wkt);
         OSRDestroySpatialReference(srs);
         local.initialized = true;
@@ -1698,7 +1779,7 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             local.gtiff_driver, local.web_mercator_wkt,
             tile, bind_data.block_size,
             static_cast<int>(bind_data.selected_bands.size()), bind_data.gdal_dtype,
-            state.nodata_value, state.has_nodata, tile_path);
+            state.nodata_value, state.has_nodata, tile_path, bind_data.Tms());
 
         // Pre-warp emptiness checks: build the transformer first so both
         // the geometric pre-check and the IO probe can use it. The geometric
@@ -1844,7 +1925,7 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
                 local.gtiff_driver, local.web_mercator_wkt,
                 frame.tile, bind_data.block_size,
                 static_cast<int>(bind_data.selected_bands.size()), bind_data.gdal_dtype,
-                state.nodata_value, state.has_nodata, ovr_path);
+                state.nodata_value, state.has_nodata, ovr_path, bind_data.Tms());
 
             // Decide the source overview level upfront so the pre-warp
             // probe and the warp itself share one transformer. -1 means
@@ -2020,9 +2101,11 @@ static void ReadRasterExecute(ClientContext &context, TableFunctionInput &data,
             }
         }
         // Build metadata
+        auto meta_tms = bind_data.Tms();
         raquet::RaquetMetadata meta;
         meta.file_format = "raquet";
-        meta.crs = "EPSG:3857";
+        meta.crs = meta_tms.crs();                  // EPSG:3857 or OGC:CRS84
+        meta.tile_matrix_set = meta_tms.name();     // WebMercatorQuad / GoogleCRS84Quad
         meta.compression = bind_data.compression;
         meta.compression_quality = bind_data.compression_quality;
         meta.band_layout = bind_data.band_layout;
@@ -2160,6 +2243,7 @@ void RegisterReadRaster(ExtensionLoader &loader) {
     func.named_parameters["statistics"] = LogicalType::BOOLEAN;
     func.named_parameters["zoom_strategy"] = LogicalType::VARCHAR;
     func.named_parameters["format"] = LogicalType::VARCHAR;
+    func.named_parameters["tile_matrix_set"] = LogicalType::VARCHAR;
     func.named_parameters["approx"] = LogicalType::BOOLEAN;
     func.named_parameters["sparsity_probe"] = LogicalType::VARCHAR;
     func.named_parameters["sparsity_probe_size"] = LogicalType::INTEGER;

--- a/src/table_functions/merge_bands.cpp
+++ b/src/table_functions/merge_bands.cpp
@@ -123,6 +123,8 @@ static raquet::RaquetMetadata BuildMergedMetadata(
         const auto &mi = metas[i];
         if (m0.compression  != mi.compression)  fail_str("compression",  m0.compression,  mi.compression,  i);
         if (m0.crs          != mi.crs)          fail_str("crs",          m0.crs,          mi.crs,          i);
+        if (m0.tile_matrix_set != mi.tile_matrix_set)
+            fail_str("tile_matrix_set", m0.tile_matrix_set, mi.tile_matrix_set, i);
         if (m0.block_width  != mi.block_width)  fail_int("block_width",  m0.block_width,  mi.block_width,  i);
         if (m0.block_height != mi.block_height) fail_int("block_height", m0.block_height, mi.block_height, i);
         if (m0.min_zoom     != mi.min_zoom)     fail_int("min_zoom",     m0.min_zoom,     mi.min_zoom,     i);

--- a/test/sql/merge_bands.test
+++ b/test/sql/merge_bands.test
@@ -58,11 +58,11 @@ SELECT count(*) FROM information_schema.columns WHERE table_name = 'merged_v050'
 ----
 5
 
-# Version preserved from inputs
+# Output carries the current format version (re-serialized via to_json()).
 query I
 SELECT json_extract_string(metadata, '$.version') FROM merged_v050 WHERE block = 0
 ----
-0.5.0
+0.6.0
 
 # Output uses v0.5.0 nested-tiling shape (key test for the parse_metadata
 # round-trip — pre-refactor, the splice approach silently no-op'd on

--- a/test/sql/metadata_validation.test
+++ b/test/sql/metadata_validation.test
@@ -180,7 +180,8 @@ SELECT (raquet_validate_metadata('{
 true	true
 
 # =============================================================================
-# Non-standard CRS → warning
+# CRS inconsistent with (defaulted) tile_matrix_set → warning
+# crs=EPSG:4326 with no tile_matrix_set → defaults to WebMercatorQuad (EPSG:3857).
 # =============================================================================
 
 query II
@@ -197,7 +198,7 @@ SELECT (raquet_validate_metadata('{
   "crs":"EPSG:4326",
   "tiling":{"scheme":"quadbin","min_zoom":0,"max_zoom":3,"block_width":256,"block_height":256},
   "bands":[{"name":"band_1","type":"uint8"}]
-}')).warnings, 'Non-standard CRS: EPSG:4326 (expected EPSG:3857)');
+}')).warnings, 'CRS EPSG:4326 does not match tile_matrix_set WebMercatorQuad (expected EPSG:3857)');
 ----
 true	true
 
@@ -216,6 +217,50 @@ SELECT (raquet_validate_metadata('{
   "tiling":{"scheme":"quadbin","min_zoom":0,"max_zoom":3,"block_width":640,"block_height":256},
   "bands":[{"name":"band_1","type":"uint8"}]
 }')).warnings, 'Non-standard block_width: 640');
+----
+true	true
+
+# =============================================================================
+# v0.6.0 tile_matrix_set validation
+# =============================================================================
+
+# GoogleCRS84Quad with matching crs (OGC:CRS84) → valid, no warnings.
+query II
+SELECT (raquet_validate_metadata('{
+  "file_format":"raquet","compression":"gzip","crs":"OGC:CRS84","tile_matrix_set":"GoogleCRS84Quad",
+  "tiling":{"scheme":"quadbin","min_zoom":0,"max_zoom":3,"block_width":256,"block_height":256},
+  "bands":[{"name":"band_1","type":"uint8"}]
+}')).is_valid,
+       len((raquet_validate_metadata('{
+  "file_format":"raquet","compression":"gzip","crs":"OGC:CRS84","tile_matrix_set":"GoogleCRS84Quad",
+  "tiling":{"scheme":"quadbin","min_zoom":0,"max_zoom":3,"block_width":256,"block_height":256},
+  "bands":[{"name":"band_1","type":"uint8"}]
+}')).warnings);
+----
+true	0
+
+# EPSG:4326 accepted as an alias of OGC:CRS84 for GoogleCRS84Quad → no warning.
+query I
+SELECT len((raquet_validate_metadata('{
+  "file_format":"raquet","compression":"gzip","crs":"EPSG:4326","tile_matrix_set":"GoogleCRS84Quad",
+  "tiling":{"scheme":"quadbin","min_zoom":0,"max_zoom":3,"block_width":256,"block_height":256},
+  "bands":[{"name":"band_1","type":"uint8"}]
+}')).warnings);
+----
+0
+
+# Unknown tile_matrix_set → warning, still structurally valid.
+query II
+SELECT (raquet_validate_metadata('{
+  "file_format":"raquet","compression":"gzip","crs":"EPSG:3857","tile_matrix_set":"BananaQuad",
+  "tiling":{"scheme":"quadbin","min_zoom":0,"max_zoom":3,"block_width":256,"block_height":256},
+  "bands":[{"name":"band_1","type":"uint8"}]
+}')).is_valid,
+       list_contains((raquet_validate_metadata('{
+  "file_format":"raquet","compression":"gzip","crs":"EPSG:3857","tile_matrix_set":"BananaQuad",
+  "tiling":{"scheme":"quadbin","min_zoom":0,"max_zoom":3,"block_width":256,"block_height":256},
+  "bands":[{"name":"band_1","type":"uint8"}]
+}')).warnings, 'Unknown tile_matrix_set: BananaQuad');
 ----
 true	true
 

--- a/test/sql/tile_matrix_set.test
+++ b/test/sql/tile_matrix_set.test
@@ -1,0 +1,99 @@
+# name: test/sql/tile_matrix_set.test
+# description: read_raster() ingest coverage for the v0.6.0 tile_matrix_set
+#              parameter — WebMercatorQuad (default) vs GoogleCRS84Quad
+#              (WGS84/CRS84): emitted crs/version, value validation, the
+#              v0-format guard, and parquet round-trip of the TMS marker.
+#              Gated on json (like the other read_raster ingest tests) since it
+#              needs the CI GDAL environment; TMS *validation* (no GDAL) lives
+#              in metadata_validation.test.
+# group: [raquet]
+
+require raquet
+
+require parquet
+
+require json
+
+# ============================================================================
+# Fixture: test/data/test_palette.tif — 16x16 uint8 single-band palette
+# raster in EPSG:4326. Being already-WGS84, GoogleCRS84Quad needs no warp.
+# overviews='none' keeps the row count small/deterministic.
+# ============================================================================
+
+# ---------- default → WebMercatorQuad ---------------------------------------
+# No tile_matrix_set param: defaults to WebMercatorQuad / EPSG:3857. Version
+# is bumped to 0.6.0 (the field was added to the schema).
+query III
+SELECT json_extract_string(metadata, '$.tile_matrix_set'),
+       json_extract_string(metadata, '$.crs'),
+       json_extract_string(metadata, '$.version')
+FROM read_raster('test/data/test_palette.tif', overviews='none')
+WHERE block = 0
+----
+WebMercatorQuad	EPSG:3857	0.6.0
+
+# ---------- explicit GoogleCRS84Quad ----------------------------------------
+# crs follows the TMS (OGC:CRS84), tile_matrix_set is declared, version 0.6.0.
+query III
+SELECT json_extract_string(metadata, '$.tile_matrix_set'),
+       json_extract_string(metadata, '$.crs'),
+       json_extract_string(metadata, '$.version')
+FROM read_raster('test/data/test_palette.tif',
+                  tile_matrix_set='GoogleCRS84Quad', overviews='none')
+WHERE block = 0
+----
+GoogleCRS84Quad	OGC:CRS84	0.6.0
+
+# ---------- value is case-insensitive, stored canonically -------------------
+query I
+SELECT json_extract_string(metadata, '$.tile_matrix_set')
+FROM read_raster('test/data/test_palette.tif',
+                  tile_matrix_set='googlecrs84quad', overviews='none')
+WHERE block = 0
+----
+GoogleCRS84Quad
+
+# ---------- produces data tiles (more than just the metadata row) -----------
+query I
+SELECT count(*) > 1
+FROM read_raster('test/data/test_palette.tif',
+                  tile_matrix_set='GoogleCRS84Quad', overviews='none')
+----
+true
+
+# ---------- WebMercatorQuad explicitly == default behavior ------------------
+query II
+SELECT json_extract_string(metadata, '$.tile_matrix_set'),
+       json_extract_string(metadata, '$.crs')
+FROM read_raster('test/data/test_palette.tif',
+                  tile_matrix_set='WebMercatorQuad', overviews='none')
+WHERE block = 0
+----
+WebMercatorQuad	EPSG:3857
+
+# ---------- invalid value rejected ------------------------------------------
+statement error
+SELECT * FROM read_raster('test/data/test_palette.tif', tile_matrix_set='EPSG:4326')
+----
+tile_matrix_set must be
+
+# ---------- GoogleCRS84Quad incompatible with legacy v0 format ---------------
+statement error
+SELECT * FROM read_raster('test/data/test_palette.tif',
+                           tile_matrix_set='GoogleCRS84Quad', format='v0')
+----
+requires format='v0.5.0'
+
+# ---------- parquet round-trip preserves the TMS marker ----------------------
+statement ok
+COPY (SELECT * FROM read_raster('test/data/test_palette.tif',
+                                 tile_matrix_set='GoogleCRS84Quad', overviews='none'))
+TO 'duckdb_unittest_tempdir/tms_crs84.parquet' (FORMAT parquet)
+
+query II
+SELECT json_extract_string(metadata, '$.tile_matrix_set'),
+       json_extract_string(metadata, '$.crs')
+FROM 'duckdb_unittest_tempdir/tms_crs84.parquet'
+WHERE block = 0
+----
+GoogleCRS84Quad	OGC:CRS84


### PR DESCRIPTION
## Summary

Adds a `tile_matrix_set` option to `read_raster()` and the raquet metadata so files can be georeferenced with **GoogleCRS84Quad** (CRS84 / WGS84 plate carrée) in addition to the default **WebMercatorQuad**. Motivation: Web Mercator distorts area at high latitudes and forces a reprojection of the very common WGS84 source rasters; QUADBIN cell bits are identical across both grids, so the only thing needed is a discriminator that tells consumers how to map cells to coordinates.

Bumps the RaQuet format version **0.5.0 → 0.6.0** (additive, backward-compatible: a missing `tile_matrix_set` reads as `WebMercatorQuad`, so existing files are unaffected).

## What's in it

- **`quadbin.hpp`** — a `TileMatrixSet` strategy. `WebMercatorQuad` delegates to the existing functions (output is **byte-identical** to today); `GoogleCRS84Quad` adds single-root, square-grid, plate-carrée math. Pure cell algebra untouched.
- **`read_raster.cpp`** — a `tile_matrix_set` named parameter; TMS-driven warp target SRS, tile geotransform, and zoom calc (degree grid for CRS84). Emits `crs`/`tile_matrix_set`. Rejects `GoogleCRS84Quad` with the legacy `format='v0'`.
- **metadata** (`raquet_metadata.hpp` / `.cpp`) — `tile_matrix_set` field, version `0.6.0`, `crs` derived from the TMS; validation checks crs/TMS consistency (accepts `EPSG:4326` as an alias of `OGC:CRS84`, warns on unknown TMS).
- **`merge_bands.cpp`** — refuses merging inputs with mismatched `tile_matrix_set`.
- **tests** — `tile_matrix_set.test` (GDAL ingest, json-gated like the other ingest tests) + GoogleCRS84Quad cases in `metadata_validation.test`.

WebMercator output is unchanged by construction.

## Validation

- Builds cleanly via the Docker image; full `.test` suite green (357 assertions; the json-gated ingest tests run in CI).
- Verified end-to-end on a real **UTM-32N Berlin** raster (the general PROJ reprojection path):
  - default → `WebMercatorQuad | EPSG:3857`; `tile_matrix_set='GoogleCRS84Quad'` → `GoogleCRS84Quad | OGC:CRS84`, both reporting identical WGS84 bounds.
  - Decoded the produced GoogleCRS84Quad cells: all land on Berlin via plate-carrée (`all_in_berlin = true`); the same cells decoded as Mercator land at ~71.8°N — the silent error this field prevents.

## Cross-repo context / gating

This is the **producer** side. Consuming a GoogleCRS84Quad file correctly also requires:
- **`@deck.gl/carto`** — TMS-aware decode (in progress on a sibling branch).
- **CARTO Map API / bigquery-raquet** — parse v0.6.0 metadata + pass `tile_matrix_set` through.

Until those land, WGS84 files should not be surfaced to users (a non-TMS-aware consumer silently misplaces them). Existing Mercator files/consumers are unaffected.

## Not included (follow-ups)

- Read-side helpers (`ST_RasterValue`, clip) remain WebMercator-only.
- `raquet_parse_metadata` doesn't yet surface `tile_matrix_set`/`crs` as struct fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
