### PR TITLE
chore: sync community-extensions descriptor to 0.2.6

### DIFF
--- a/community-extensions/description.yml
+++ b/community-extensions/description.yml
@@ -5,17 +5,18 @@
 extension:
   name: raquet
   description: "Raster analytics on Raquet files with QUADBIN spatial indexing, raster ingestion, and PostGIS-style functions"
-  version: 0.2.0
+  version: 0.2.6
   language: C++
   build: cmake
   license: Apache-2.0
   excluded_platforms: "windows_amd64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
   maintainers:
     - jatorre
+    - cayetanobv
 
 repo:
   github: jatorre/duckdb-raquet
-  ref: c5c0f821fddcccb0bc1c3a8346c1ef1f16d6c158
+  ref: e077a7c36f4527949cd5e36719cf4c81289d9d4b
 
 docs:
   hello_world: |


### PR DESCRIPTION
The in-repo `community-extensions/description.yml` template had drifted: it said `version: 0.2.0` / `ref: c5c0f82`, while the published registry entry was already at **0.2.5**.

This brings the template in line with the **0.2.6** descriptor submitted in duckdb/community-extensions#2039:

- `version`: 0.2.0 → **0.2.6**
- `ref`: `c5c0f82` → **`e077a7c`** (current `main`)
- add `cayetanobv` to maintainers (matches the registered descriptor)

Docs/description fields are unchanged. Template-only change — no code or build impact.